### PR TITLE
모임 장소 기능

### DIFF
--- a/meeting-service/src/docs/asciidoc/Create-Place.adoc
+++ b/meeting-service/src/docs/asciidoc/Create-Place.adoc
@@ -1,0 +1,44 @@
+[[Create-Place]]
+== 1. 장소 생성 - **/meeting-places**
+
+[[Create-Place-Normal]]
+=== 1) 정상 흐름
+==== 요청 예시
+include::{snippets}/place-create-normal/http-request.adoc[]
+application/json 타입으로 아래의 요청 필드를 확인하여 요청을 보내주세요.
+
+==== 요청 필드
+include::{snippets}/place-create-normal/request-fields.adoc[]
+필수값이 true인 필드 값은 무조건 작성해야 합니다.
+
+==== 응답 예시
+include::{snippets}/place-create-normal/http-response.adoc[]
+생성에 성공한 모임 장소의 식별자 값을 응답합니다.
+
+[[Create-Place-Error-Param]]
+=== 2) 예외 - 필수값이 없는 경우
+==== 요청 예시
+include::{snippets}/place-create-error-param/http-request.adoc[]
+위의 예시는 필수 데이터를 보내지 않은 경우입니다. +
+필수 데이터 값을 null로 보내도 마찬가지입니다.
+
+==== 응답 예시
+include::{snippets}/place-create-error-param/http-response.adoc[]
+
+==== 응답 필드
+include::{snippets}/place-create-error-param/response-fields-data.adoc[]
+모임이 없기 때문에 해당 모임에 장소를 등록할 수 없어 위와 같이 예외를 응답합니다.
+
+
+[[Create-Place-Error-MeetingId]]
+=== 3) 예외 - 모임 ID가 잘못된 경우
+==== 요청 예시
+include::{snippets}/place-create-error-meetingid/http-request.adoc[]
+위의 예시는 5번 식별자를 가진 모임이 없음에도 서버에 모임 장소 생성 요청을 보낸 경우입니다.
+
+==== 응답 예시
+include::{snippets}/place-create-error-meetingid/http-response.adoc[]
+
+==== 응답 필드
+include::{snippets}/place-create-error-meetingid/response-fields-data.adoc[]
+모임이 없기 때문에 해당 모임에 장소를 등록할 수 없어 위와 같이 예외를 응답합니다.

--- a/meeting-service/src/docs/asciidoc/Delete-Place.adoc
+++ b/meeting-service/src/docs/asciidoc/Delete-Place.adoc
@@ -1,0 +1,26 @@
+[[Delete-Place]]
+== 3. 장소 삭제 - **/meeting-places/{meetingPlaceId}**
+
+[[Delete-Place-Normal]]
+=== 1) 정상 흐름 - 장소 정보 수정
+==== 요청 예시
+include::{snippets}/place-delete-normal/http-request.adoc[]
+수정할 모임의 ID를 경로변수에 담아 DELETE 메서드로 호출해주세요. +
+
+==== 응답 예시
+include::{snippets}/place-delete-normal/http-response.adoc[]
+응답코드가 SUCCESS로 응답된다면 정상적으로 처리된 것입니다. 응답 데이터는 따로 없습니다.
+
+[[Delete-Place-Error-Pathvariable]]
+=== 2) 예외 - 잘못된 경로변수를 보낼 경우
+
+==== 요청 예시
+include::{snippets}/place-delete-error-pathvariable/http-request.adoc[]
+위의 예시는 5번 식별자를 가진 모임이 없음에도 서버에 삭제 요청을 보낸 경우입니다.
+
+==== 응답 예시
+include::{snippets}/place-delete-error-pathvariable/http-response.adoc[]
+
+==== 응답 필드
+include::{snippets}/place-delete-error-pathvariable/response-fields-data.adoc[]
+삭제하려는 모임이 없기 때문에 위와 같이 예외를 응답합니다.

--- a/meeting-service/src/docs/asciidoc/Detail-Place.adoc
+++ b/meeting-service/src/docs/asciidoc/Detail-Place.adoc
@@ -1,0 +1,30 @@
+[[Detail-Place]]
+== 4. 장소 단건 조회 **/meeting-places/{meetingPlaceId}**
+
+[[Detail-Place-Normal]]
+=== 1) 정상 흐름
+==== 요청 예시
+include::{snippets}/place-detail-normal/http-request.adoc[]
+조회하려는 모임 장소의 ID를 경로변수에 작성하여 GET 메서드로 호출해주세요.
+
+==== 응답 예시
+include::{snippets}/place-detail-normal/http-response.adoc[]
+
+==== 응답 필드
+include::{snippets}/place-detail-normal/response-fields-data.adoc[]
+data에 응답되는 필드는 위와 같습니다. +
+장소의 이름, 위도, 경도를 응답합니다.
+
+[[Detail-Place-Error-Pathvariable]]
+=== 2) 예외 - 잘못된 경로변수를 보낼 경우
+==== 요청 예시
+include::{snippets}/place-detail-error-pathvariable/http-request.adoc[]
+위의 예시는 5번 식별자를 가진 장소가 없음에도 서버에 조회 요청을 보낸 경우입니다.
+
+==== 응답 예시
+include::{snippets}/place-detail-error-pathvariable/http-response.adoc[]
+
+==== 응답 필드
+include::{snippets}/place-detail-error-pathvariable/response-fields-data.adoc[]
+조회하려는 장소가 없기 때문에 위와 같이 예외를 응답합니다.
+

--- a/meeting-service/src/docs/asciidoc/Modify-Meeting.adoc
+++ b/meeting-service/src/docs/asciidoc/Modify-Meeting.adoc
@@ -34,20 +34,24 @@ include::{snippets}/meeting-modify-normal/http-response.adoc[]
 
 [[Modify-Error-Param]]
 === 3) 예외 - 필수값이 없는 경우
-요청 데이터에 필수데이터(title, startDate, endDate)를 명시하지 않는다면 아래와 같은 응답을 보냅니다.
+include::{snippets}/meeting-modify-error-param/http-request.adoc[]
+위의 예시는 필수 데이터인 title, startDate를 포함하지 않고 요청을 보낸 경우입니다.
 
 ==== 응답 예시
 include::{snippets}/meeting-modify-error-param/http-response.adoc[]
 
 ==== 응답 필드
 include::{snippets}/meeting-modify-error-param/response-fields-data.adoc[]
+필수 데이터가 없기 때문에 위와 같이 예외를 응답합니다.
 
 [[Modify-Error-Pathvariable]]
 === 4) 예외 - 잘못된 경로변수를 보낼 경우
-경로 변수에 없는 모임 리소스의 PK값을 명시할 경우 아래와 같은 응답을 보냅니다.
+include::{snippets}/meeting-modify-error-pathvariable/http-request.adoc[]
+위의 예시는 5번 식별자를 가진 모임이 없음에도 서버에 수정 요청을 보낸 경우입니다.
 
 ==== 응답 예시
 include::{snippets}/meeting-modify-error-pathvariable/http-response.adoc[]
 
 ==== 응답 필드
 include::{snippets}/meeting-modify-error-pathvariable/response-fields-data.adoc[]
+수정하려는 모임이 없기 때문에 위와 같이 예외를 응답합니다.

--- a/meeting-service/src/docs/asciidoc/Modify-Place.adoc
+++ b/meeting-service/src/docs/asciidoc/Modify-Place.adoc
@@ -1,0 +1,83 @@
+[[Modify-Place]]
+== 2. 장소 수정 - **/meeting-places/{meetingPlaceId}**
+모임 장소를 수정기능은 장소 정보(name, lat, lng), 장소 메모(memo), 장소 순서(order)를 수정할 수 있도록 설계되어 있습니다. +
+
+name, lat, lng 필드만 요청 데이터로 보낸다면, 장소 정보만 수정됩니다. +
+memo 필드만 요청 데이터로 보낸다면, 장소 메모만 수정됩니다. +
+order 필드만 요청 데이터로 보낸다면, 장소 순서만 수정됩니다. +
+
+추가로 세 가지 수정 기능을 한번에 이용할 수도 있습니다. +
+예를 들어 name, lat, lng, memo, order 필드를 모두 요청 데이터로 보낸다면, 장소 정보, 메모, 순서 모두 수정 가능합니다. +
+
+자세한 내용은 아래의 문서들을 참고하여 상황에 따라 적절하게 호출해주세요.
+
+[[Modify-Place-Normal-Info]]
+=== 1) 정상 흐름 - 장소 정보 수정
+==== 요청 예시
+include::{snippets}/place-modify-normal-info/http-request.adoc[]
+수정할 모임의 ID를 경로변수에 담아 PATCH 메서드로 호출해주세요. +
+application/json 형식으로 name, lat, lng 필드의 값을 넣어서 보내주세요.
+
+==== 요청 필드
+include::{snippets}/place-modify-normal-info/request-fields.adoc[]
+필수값이 true인 필드 값은 무조건 작성해야 합니다.
+
+==== 응답 예시
+include::{snippets}/place-modify-normal-info/http-response.adoc[]
+응답코드가 SUCCESS로 응답된다면 정상적으로 처리된 것입니다. 응답 데이터는 따로 없습니다.
+
+[[Modify-Place-Normal-Memo]]
+=== 2) 정상 흐름 - 장소 메모 수정
+==== 요청 예시
+include::{snippets}/place-modify-normal-memo/http-request.adoc[]
+수정할 모임의 ID를 경로변수에 담아 PATCH 메서드로 호출해주세요. +
+application/json 형식으로 memo 필드의 값을 넣어서 보내주세요.
+
+==== 요청 필드
+include::{snippets}/place-modify-normal-memo/request-fields.adoc[]
+필수값이 true인 필드 값은 무조건 작성해야 합니다.
+
+==== 응답 예시
+include::{snippets}/place-modify-normal-memo/http-response.adoc[]
+응답코드가 SUCCESS로 응답된다면 정상적으로 처리된 것입니다. 응답 데이터는 따로 없습니다.
+
+[[Modify-Place-Normal-Order]]
+=== 3) 정상 흐름 - 장소 순서 수정
+==== 요청 예시
+include::{snippets}/place-modify-normal-order/http-request.adoc[]
+수정할 모임의 ID를 경로변수에 담아 PATCH 메서드로 호출해주세요. +
+application/json 형식으로 order 필드의 값을 넣어서 보내주세요.
+
+==== 요청 필드
+include::{snippets}/place-modify-normal-order/request-fields.adoc[]
+필수값이 true인 필드 값은 무조건 작성해야 합니다.
+
+==== 응답 예시
+include::{snippets}/place-modify-normal-order/http-response.adoc[]
+응답코드가 SUCCESS로 응답된다면 정상적으로 처리된 것입니다. 응답 데이터는 따로 없습니다.
+
+[[Modify-Place-Error-Info]]
+=== 4) 예외 - 장소 정보 데이터가 하나라도 없는 경우
+==== 요청 예시
+include::{snippets}/place-modify-error-info-required/http-request.adoc[]
+위의 예시는 name, lat 필드는 요청 데이터에 포함되어 있지만, lng 필드는 null인 경우입니다.
+
+==== 응답 예시
+include::{snippets}/place-modify-error-info-required/http-response.adoc[]
+이럴 경우 클라이언트가 장소 정보를 수정하려고 시도했다는 것으로 판단하고 lng 필드가 포함되어있지 않기 때문에 예외를 표시합니다.
+
+==== 응답 필드
+include::{snippets}/place-modify-error-info-required/response-fields-data.adoc[]
+
+[[Modify-Place-Error-Pathvariable]]
+=== 5) 예외 - 잘못된 경로변수를 보낼 경우
+==== 요청 예시
+include::{snippets}/place-modify-error-pathvariable/http-request.adoc[]
+위의 예시는 5번 식별자를 가진 모임이 없음에도 서버에 수정 요청을 보낸 경우입니다.
+
+==== 응답 예시
+include::{snippets}/place-modify-error-pathvariable/http-response.adoc[]
+
+==== 응답 필드
+include::{snippets}/place-modify-error-pathvariable/response-fields-data.adoc[]
+수정하려는 모임이 없기 때문에 위와 같이 예외를 응답합니다.

--- a/meeting-service/src/docs/asciidoc/index.adoc
+++ b/meeting-service/src/docs/asciidoc/index.adoc
@@ -35,3 +35,5 @@ include::Detail-Meeting.adoc[]
 include::Create-Place.adoc[]
 
 include::Modify-Place.adoc[]
+
+include::Delete-Place.adoc[]

--- a/meeting-service/src/docs/asciidoc/index.adoc
+++ b/meeting-service/src/docs/asciidoc/index.adoc
@@ -33,3 +33,5 @@ include::Detail-Meeting.adoc[]
 = 모임 장소
 
 include::Create-Place.adoc[]
+
+include::Modify-Place.adoc[]

--- a/meeting-service/src/docs/asciidoc/index.adoc
+++ b/meeting-service/src/docs/asciidoc/index.adoc
@@ -37,3 +37,5 @@ include::Create-Place.adoc[]
 include::Modify-Place.adoc[]
 
 include::Delete-Place.adoc[]
+
+include::Detail-Place.adoc[]

--- a/meeting-service/src/docs/asciidoc/index.adoc
+++ b/meeting-service/src/docs/asciidoc/index.adoc
@@ -28,3 +28,8 @@ include::Delete-Meeting.adoc[]
 include::List-Meeting.adoc[]
 
 include::Detail-Meeting.adoc[]
+
+[[모임장소]]
+= 모임 장소
+
+include::Create-Place.adoc[]

--- a/meeting-service/src/main/java/com/comeon/meetingservice/domain/meeting/entity/MeetingEntity.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/domain/meeting/entity/MeetingEntity.java
@@ -1,6 +1,7 @@
 package com.comeon.meetingservice.domain.meeting.entity;
 
 import com.comeon.meetingservice.domain.common.BaseEntity;
+import com.comeon.meetingservice.domain.meetingplace.entity.MeetingPlaceEntity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/meeting-service/src/main/java/com/comeon/meetingservice/domain/meeting/repository/MeetingRepository.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/domain/meeting/repository/MeetingRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 
 public interface MeetingRepository extends JpaRepository<MeetingEntity, Long> {
 
+    @Query("select m from MeetingEntity m left join fetch m.meetingPlaceEntities where m.id = :id")
+    Optional<MeetingEntity> findByIdFetchPlace(@Param("id") Long id);
 }

--- a/meeting-service/src/main/java/com/comeon/meetingservice/domain/meetingplace/dto/MeetingPlaceModifyDto.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/domain/meetingplace/dto/MeetingPlaceModifyDto.java
@@ -1,0 +1,24 @@
+package com.comeon.meetingservice.domain.meetingplace.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter @Setter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+public class MeetingPlaceModifyDto {
+
+    private Long id;
+
+    private String name;
+    private Double lat;
+    private Double lng;
+
+    private String memo;
+
+    private Integer order;
+}

--- a/meeting-service/src/main/java/com/comeon/meetingservice/domain/meetingplace/dto/MeetingPlaceRemoveDto.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/domain/meetingplace/dto/MeetingPlaceRemoveDto.java
@@ -1,0 +1,17 @@
+package com.comeon.meetingservice.domain.meetingplace.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter @Setter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+public class MeetingPlaceRemoveDto {
+
+    private Long id;
+
+}

--- a/meeting-service/src/main/java/com/comeon/meetingservice/domain/meetingplace/dto/MeetingPlaceSaveDto.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/domain/meetingplace/dto/MeetingPlaceSaveDto.java
@@ -1,0 +1,20 @@
+package com.comeon.meetingservice.domain.meetingplace.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+public class MeetingPlaceSaveDto {
+
+    private Long meetingId;
+    private String name;
+    private Double lat;
+    private Double lng;
+}

--- a/meeting-service/src/main/java/com/comeon/meetingservice/domain/meetingplace/entity/MeetingPlaceEntity.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/domain/meetingplace/entity/MeetingPlaceEntity.java
@@ -1,6 +1,7 @@
-package com.comeon.meetingservice.domain.meeting.entity;
+package com.comeon.meetingservice.domain.meetingplace.entity;
 
 import com.comeon.meetingservice.domain.common.BaseEntity;
+import com.comeon.meetingservice.domain.meeting.entity.MeetingEntity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -49,5 +50,9 @@ public class MeetingPlaceEntity extends BaseEntity {
 
     public void addMeetingEntity(MeetingEntity meetingEntity) {
         this.meetingEntity = meetingEntity;
+    }
+
+    public void updateOrder(Integer order) {
+        this.order = order;
     }
 }

--- a/meeting-service/src/main/java/com/comeon/meetingservice/domain/meetingplace/entity/MeetingPlaceEntity.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/domain/meetingplace/entity/MeetingPlaceEntity.java
@@ -52,7 +52,25 @@ public class MeetingPlaceEntity extends BaseEntity {
         this.meetingEntity = meetingEntity;
     }
 
+    public void updateMemo(String memo) {
+        this.memo = memo;
+    }
+
     public void updateOrder(Integer order) {
         this.order = order;
+    }
+
+    public void increaseOrder() {
+        this.order += 1;
+    }
+
+    public void decreaseOrder() {
+        this.order -= 1;
+    }
+
+    public void updateInfo(String name, Double lat, Double lng) {
+        this.name = name;
+        this.lat = lat;
+        this.lng = lng;
     }
 }

--- a/meeting-service/src/main/java/com/comeon/meetingservice/domain/meetingplace/repository/MeetingPlaceRepository.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/domain/meetingplace/repository/MeetingPlaceRepository.java
@@ -2,6 +2,13 @@ package com.comeon.meetingservice.domain.meetingplace.repository;
 
 import com.comeon.meetingservice.domain.meetingplace.entity.MeetingPlaceEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface MeetingPlaceRepository extends JpaRepository<MeetingPlaceEntity, Long> {
+
+    @Query("select mp from MeetingPlaceEntity mp where mp.meetingEntity.id = :meetingId")
+    List<MeetingPlaceEntity> findAllByMeetingId(@Param("meetingId") Long meetingId);
 }

--- a/meeting-service/src/main/java/com/comeon/meetingservice/domain/meetingplace/repository/MeetingPlaceRepository.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/domain/meetingplace/repository/MeetingPlaceRepository.java
@@ -1,0 +1,7 @@
+package com.comeon.meetingservice.domain.meetingplace.repository;
+
+import com.comeon.meetingservice.domain.meetingplace.entity.MeetingPlaceEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MeetingPlaceRepository extends JpaRepository<MeetingPlaceEntity, Long> {
+}

--- a/meeting-service/src/main/java/com/comeon/meetingservice/domain/meetingplace/service/MeetingPlaceService.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/domain/meetingplace/service/MeetingPlaceService.java
@@ -1,6 +1,7 @@
 package com.comeon.meetingservice.domain.meetingplace.service;
 
 import com.comeon.meetingservice.domain.meetingplace.dto.MeetingPlaceModifyDto;
+import com.comeon.meetingservice.domain.meetingplace.dto.MeetingPlaceRemoveDto;
 import com.comeon.meetingservice.domain.meetingplace.dto.MeetingPlaceSaveDto;
 
 public interface MeetingPlaceService {
@@ -8,4 +9,6 @@ public interface MeetingPlaceService {
     Long add(MeetingPlaceSaveDto meetingPlaceSaveDto);
 
     void modify(MeetingPlaceModifyDto meetingPlaceModifyDto);
+
+    void remove(MeetingPlaceRemoveDto meetingPlaceRemoveDto);
 }

--- a/meeting-service/src/main/java/com/comeon/meetingservice/domain/meetingplace/service/MeetingPlaceService.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/domain/meetingplace/service/MeetingPlaceService.java
@@ -1,0 +1,8 @@
+package com.comeon.meetingservice.domain.meetingplace.service;
+
+import com.comeon.meetingservice.domain.meetingplace.dto.MeetingPlaceSaveDto;
+
+public interface MeetingPlaceService {
+
+    Long add(MeetingPlaceSaveDto meetingPlaceSaveDto);
+}

--- a/meeting-service/src/main/java/com/comeon/meetingservice/domain/meetingplace/service/MeetingPlaceService.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/domain/meetingplace/service/MeetingPlaceService.java
@@ -1,8 +1,11 @@
 package com.comeon.meetingservice.domain.meetingplace.service;
 
+import com.comeon.meetingservice.domain.meetingplace.dto.MeetingPlaceModifyDto;
 import com.comeon.meetingservice.domain.meetingplace.dto.MeetingPlaceSaveDto;
 
 public interface MeetingPlaceService {
 
     Long add(MeetingPlaceSaveDto meetingPlaceSaveDto);
+
+    void modify(MeetingPlaceModifyDto meetingPlaceModifyDto);
 }

--- a/meeting-service/src/main/java/com/comeon/meetingservice/domain/meetingplace/service/MeetingPlaceServiceImpl.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/domain/meetingplace/service/MeetingPlaceServiceImpl.java
@@ -1,0 +1,53 @@
+package com.comeon.meetingservice.domain.meetingplace.service;
+
+import com.comeon.meetingservice.domain.common.exception.EntityNotFoundException;
+import com.comeon.meetingservice.domain.meeting.entity.MeetingEntity;
+import com.comeon.meetingservice.domain.meeting.repository.MeetingRepository;
+import com.comeon.meetingservice.domain.meetingplace.dto.MeetingPlaceSaveDto;
+import com.comeon.meetingservice.domain.meetingplace.entity.MeetingPlaceEntity;
+import com.comeon.meetingservice.domain.meetingplace.repository.MeetingPlaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MeetingPlaceServiceImpl implements MeetingPlaceService {
+
+    private final MeetingRepository meetingRepository;
+    private final MeetingPlaceRepository meetingPlaceRepository;
+
+    @Override
+    public Long add(MeetingPlaceSaveDto meetingPlaceSaveDto) {
+        MeetingEntity meetingEntity = meetingRepository.findByIdFetchPlace(meetingPlaceSaveDto.getMeetingId())
+                .orElseThrow(() -> new EntityNotFoundException("해당 ID와 일치하는 모임을 찾을 수 없습니다."));
+
+        Integer order = calculateOrder(meetingEntity.getMeetingPlaceEntities());
+
+        MeetingPlaceEntity meetingPlaceEntity = createMeetingPlace(meetingPlaceSaveDto, order);
+        meetingPlaceEntity.addMeetingEntity(meetingEntity);
+
+        meetingPlaceRepository.save(meetingPlaceEntity);
+
+        return meetingPlaceEntity.getId();
+    }
+
+    private MeetingPlaceEntity createMeetingPlace(MeetingPlaceSaveDto meetingPlaceSaveDto, Integer order) {
+        return MeetingPlaceEntity.builder()
+                .name(meetingPlaceSaveDto.getName())
+                .lat(meetingPlaceSaveDto.getLat())
+                .lng(meetingPlaceSaveDto.getLng())
+                .order(order)
+                .build();
+    }
+
+    private Integer calculateOrder(Set<MeetingPlaceEntity> meetingPlaceEntities) {
+        int lastOrder = meetingPlaceEntities.stream()
+                .mapToInt(MeetingPlaceEntity::getOrder)
+                .max().orElse(0);
+        return lastOrder + 1;
+    }
+}

--- a/meeting-service/src/main/java/com/comeon/meetingservice/domain/meetingplace/service/MeetingPlaceServiceImpl.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/domain/meetingplace/service/MeetingPlaceServiceImpl.java
@@ -3,6 +3,7 @@ package com.comeon.meetingservice.domain.meetingplace.service;
 import com.comeon.meetingservice.domain.common.exception.EntityNotFoundException;
 import com.comeon.meetingservice.domain.meeting.entity.MeetingEntity;
 import com.comeon.meetingservice.domain.meeting.repository.MeetingRepository;
+import com.comeon.meetingservice.domain.meetingplace.dto.MeetingPlaceModifyDto;
 import com.comeon.meetingservice.domain.meetingplace.dto.MeetingPlaceSaveDto;
 import com.comeon.meetingservice.domain.meetingplace.entity.MeetingPlaceEntity;
 import com.comeon.meetingservice.domain.meetingplace.repository.MeetingPlaceRepository;
@@ -10,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 @Service
@@ -35,6 +38,22 @@ public class MeetingPlaceServiceImpl implements MeetingPlaceService {
         return meetingPlaceEntity.getId();
     }
 
+    @Override
+    public void modify(MeetingPlaceModifyDto meetingPlaceModifyDto) {
+        MeetingPlaceEntity meetingPlaceEntity = meetingPlaceRepository.findById(meetingPlaceModifyDto.getId()).orElseThrow(() ->
+                new EntityNotFoundException("해당 ID와 일치하는 모임 장소를 찾을 수 없습니다."));
+
+        if (Objects.nonNull(meetingPlaceModifyDto.getMemo())) {
+            meetingPlaceEntity.updateMemo(meetingPlaceModifyDto.getMemo());
+        }
+        if (Objects.nonNull(meetingPlaceModifyDto.getOrder())) {
+            updatePlaceOrder(meetingPlaceEntity, meetingPlaceModifyDto);
+        }
+        if (isInfoModified(meetingPlaceModifyDto)) {
+            updatePlaceInfo(meetingPlaceEntity, meetingPlaceModifyDto);
+        }
+    }
+
     private MeetingPlaceEntity createMeetingPlace(MeetingPlaceSaveDto meetingPlaceSaveDto, Integer order) {
         return MeetingPlaceEntity.builder()
                 .name(meetingPlaceSaveDto.getName())
@@ -49,5 +68,48 @@ public class MeetingPlaceServiceImpl implements MeetingPlaceService {
                 .mapToInt(MeetingPlaceEntity::getOrder)
                 .max().orElse(0);
         return lastOrder + 1;
+    }
+
+    private void updatePlaceOrder(MeetingPlaceEntity meetingPlaceEntity, MeetingPlaceModifyDto meetingPlaceModifyDto) {
+        List<MeetingPlaceEntity> meetingPlaceEntities =
+                meetingPlaceRepository.findAllByMeetingId(meetingPlaceEntity.getMeetingEntity().getId());
+
+        // 수정하려는 순서가 기존의 순서보다 작은 경우 (ex. 기존: 4 -> 변경: 2)
+        if (meetingPlaceEntity.getOrder() > meetingPlaceModifyDto.getOrder()) {
+
+            // 변경 순서보다 크거나 같고, 기존 순서보다 작은 엔티티들로 필터링 (ex. 2 <= x < 4 -> 순서가 2, 3인 엔티티 필터링)
+            // 이후 조회된 엔티티들의 순서를 1 증가 (ex. 2, 3 -> 3, 4)
+            meetingPlaceEntities.stream()
+                    .filter(mp -> mp.getOrder() >= meetingPlaceModifyDto.getOrder()
+                            && mp.getOrder() < meetingPlaceEntity.getOrder())
+                    .forEach(MeetingPlaceEntity::increaseOrder);
+
+            // 수정하려는 순서가 기존의 순서보다 큰 경우 (ex. 기존: 2 -> 변경: 4)
+        } else if (meetingPlaceEntity.getOrder() < meetingPlaceModifyDto.getOrder()) {
+
+            // 변경 순서보다 작거나 같고, 기존 순서보다 큰 엔티티들로 필터링 (ex. 4 >= x > 2 -> 순서가 3, 4인 엔티티 필터링)
+            // 이후 조회된 엔티티들의 순서를 1 감소 (ex. 3, 4 -> 2, 3)
+            meetingPlaceEntities.stream()
+                    .filter(mp -> mp.getOrder() <= meetingPlaceModifyDto.getOrder()
+                            && mp.getOrder() > meetingPlaceEntity.getOrder())
+                    .forEach(MeetingPlaceEntity::decreaseOrder);
+        }
+
+        // 최종적으로 변경 순서 값으로 수정 엔티티 순서 변경
+        meetingPlaceEntity.updateOrder(meetingPlaceModifyDto.getOrder());
+    }
+
+    private boolean isInfoModified(MeetingPlaceModifyDto meetingPlaceModifyDto) {
+        return Objects.nonNull(meetingPlaceModifyDto.getName())
+                && Objects.nonNull(meetingPlaceModifyDto.getLat())
+                && Objects.nonNull(meetingPlaceModifyDto.getLng());
+    }
+
+    private void updatePlaceInfo(MeetingPlaceEntity meetingPlaceEntity,
+                                 MeetingPlaceModifyDto meetingPlaceModifyDto) {
+        meetingPlaceEntity.updateInfo(meetingPlaceModifyDto.getName(),
+                meetingPlaceModifyDto.getLat(),
+                meetingPlaceModifyDto.getLng()
+        );
     }
 }

--- a/meeting-service/src/main/java/com/comeon/meetingservice/web/common/util/ValidationUtils.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/web/common/util/ValidationUtils.java
@@ -1,8 +1,11 @@
 package com.comeon.meetingservice.web.common.util;
 
 import com.comeon.meetingservice.web.common.exception.ValidationFailException;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
 
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -11,8 +14,12 @@ public class ValidationUtils {
 
     public static void validate(BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
-            Map<String, String> errorMap = bindingResult.getFieldErrors().stream()
-                    .collect(Collectors.toMap(FieldError::getField, FieldError::getDefaultMessage));
+            MultiValueMap<String, String> errorMap = new LinkedMultiValueMap<>();
+            bindingResult.getGlobalErrors().stream()
+                    .forEach(oe -> errorMap.add("Object Error", oe.getDefaultMessage()));
+
+            bindingResult.getFieldErrors().stream()
+                    .forEach(fe -> errorMap.add(fe.getField(), fe.getDefaultMessage()));
 
             throw new ValidationFailException(errorMap.toString());
         }

--- a/meeting-service/src/main/java/com/comeon/meetingservice/web/meeting/response/MeetingDetailPlaceResponse.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/web/meeting/response/MeetingDetailPlaceResponse.java
@@ -1,6 +1,6 @@
 package com.comeon.meetingservice.web.meeting.response;
 
-import com.comeon.meetingservice.domain.meeting.entity.MeetingPlaceEntity;
+import com.comeon.meetingservice.domain.meetingplace.entity.MeetingPlaceEntity;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/meeting-service/src/main/java/com/comeon/meetingservice/web/meeting/response/MeetingDetailResponse.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/web/meeting/response/MeetingDetailResponse.java
@@ -3,7 +3,7 @@ package com.comeon.meetingservice.web.meeting.response;
 import com.comeon.meetingservice.domain.common.BaseEntity;
 import com.comeon.meetingservice.domain.meeting.entity.MeetingDateEntity;
 import com.comeon.meetingservice.domain.meeting.entity.MeetingEntity;
-import com.comeon.meetingservice.domain.meeting.entity.MeetingPlaceEntity;
+import com.comeon.meetingservice.domain.meetingplace.entity.MeetingPlaceEntity;
 import com.comeon.meetingservice.domain.meeting.entity.MeetingUserEntity;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;

--- a/meeting-service/src/main/java/com/comeon/meetingservice/web/meetingplace/MeetingPlaceController.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/web/meetingplace/MeetingPlaceController.java
@@ -1,6 +1,7 @@
 package com.comeon.meetingservice.web.meetingplace;
 
 import com.comeon.meetingservice.domain.meetingplace.dto.MeetingPlaceModifyDto;
+import com.comeon.meetingservice.domain.meetingplace.dto.MeetingPlaceRemoveDto;
 import com.comeon.meetingservice.domain.meetingplace.dto.MeetingPlaceSaveDto;
 import com.comeon.meetingservice.domain.meetingplace.service.MeetingPlaceService;
 import com.comeon.meetingservice.web.common.response.ApiResponse;
@@ -45,15 +46,23 @@ public class MeetingPlaceController {
     }
 
     @PatchMapping("/{meetingPlaceId}")
-    public ApiResponse meetingPlaceModify(@PathVariable("meetingPlaceId") Long id,
+    public ApiResponse meetingPlaceModify(@PathVariable("meetingPlaceId") Long meetingPlaceId,
                                           @Validated @RequestBody MeetingPlaceModifyRequest meetingPlaceModifyRequest,
                                           BindingResult bindingResult) {
         ValidationUtils.validate(bindingResult);
 
         MeetingPlaceModifyDto meetingPlaceModifyDto = meetingPlaceModifyRequest.toDto();
-        meetingPlaceModifyDto.setId(id);
+        meetingPlaceModifyDto.setId(meetingPlaceId);
 
         meetingPlaceService.modify(meetingPlaceModifyDto);
+
+        return ApiResponse.createSuccess();
+    }
+
+    @DeleteMapping("/{meetingPlaceId}")
+    public ApiResponse meetingPlaceRemove(@PathVariable("meetingPlaceId") Long meetingPlaceId) {
+
+        meetingPlaceService.remove(MeetingPlaceRemoveDto.builder().id(meetingPlaceId).build());
 
         return ApiResponse.createSuccess();
     }

--- a/meeting-service/src/main/java/com/comeon/meetingservice/web/meetingplace/MeetingPlaceController.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/web/meetingplace/MeetingPlaceController.java
@@ -1,0 +1,37 @@
+package com.comeon.meetingservice.web.meetingplace;
+
+import com.comeon.meetingservice.domain.meetingplace.dto.MeetingPlaceSaveDto;
+import com.comeon.meetingservice.domain.meetingplace.service.MeetingPlaceService;
+import com.comeon.meetingservice.web.common.response.ApiResponse;
+import com.comeon.meetingservice.web.common.util.ValidationUtils;
+import com.comeon.meetingservice.web.meetingplace.request.MeetingPlaceSaveRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/meeting-places")
+@RequiredArgsConstructor
+public class MeetingPlaceController {
+
+    private final MeetingPlaceService meetingPlaceService;
+
+    @PostMapping
+    @ResponseStatus(CREATED)
+    public ApiResponse<Long> meetingPlaceAdd(@RequestBody @Validated MeetingPlaceSaveRequest meetingPlaceSaveRequest,
+                                             BindingResult bindingResult) {
+        ValidationUtils.validate(bindingResult);
+
+        MeetingPlaceSaveDto meetingPlaceSaveDto = meetingPlaceSaveRequest.toDto();
+
+        Long savedId = meetingPlaceService.add(meetingPlaceSaveDto);
+
+        return ApiResponse.createSuccess(savedId);
+    }
+
+}

--- a/meeting-service/src/main/java/com/comeon/meetingservice/web/meetingplace/MeetingPlaceController.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/web/meetingplace/MeetingPlaceController.java
@@ -6,9 +6,11 @@ import com.comeon.meetingservice.domain.meetingplace.dto.MeetingPlaceSaveDto;
 import com.comeon.meetingservice.domain.meetingplace.service.MeetingPlaceService;
 import com.comeon.meetingservice.web.common.response.ApiResponse;
 import com.comeon.meetingservice.web.common.util.ValidationUtils;
+import com.comeon.meetingservice.web.meetingplace.query.MeetingPlaceQueryService;
 import com.comeon.meetingservice.web.meetingplace.request.MeetingPlaceModifyRequest;
 import com.comeon.meetingservice.web.meetingplace.request.MeetingPlaceSaveRequest;
 import com.comeon.meetingservice.web.meetingplace.request.PlaceModifyRequestValidator;
+import com.comeon.meetingservice.web.meetingplace.response.MeetingPlaceDetailResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.BindingResult;
@@ -25,6 +27,7 @@ import static org.springframework.http.HttpStatus.*;
 public class MeetingPlaceController {
 
     private final MeetingPlaceService meetingPlaceService;
+    private final MeetingPlaceQueryService meetingPlaceQueryService;
     private final PlaceModifyRequestValidator placeModifyRequestValidator;
 
     @InitBinder("meetingPlaceModifyRequest")
@@ -34,7 +37,7 @@ public class MeetingPlaceController {
 
     @PostMapping
     @ResponseStatus(CREATED)
-    public ApiResponse<Long> meetingPlaceAdd(@RequestBody @Validated MeetingPlaceSaveRequest meetingPlaceSaveRequest,
+    public ApiResponse<Long> meetingPlaceAdd(@Validated @RequestBody MeetingPlaceSaveRequest meetingPlaceSaveRequest,
                                              BindingResult bindingResult) {
         ValidationUtils.validate(bindingResult);
 
@@ -65,6 +68,12 @@ public class MeetingPlaceController {
         meetingPlaceService.remove(MeetingPlaceRemoveDto.builder().id(meetingPlaceId).build());
 
         return ApiResponse.createSuccess();
+    }
+
+    @GetMapping("/{meetingPlaceId}")
+    public ApiResponse<MeetingPlaceDetailResponse> meetingDetail(@PathVariable("meetingPlaceId") Long meetingId) {
+
+        return ApiResponse.createSuccess(meetingPlaceQueryService.getDetail(meetingId));
     }
 
 }

--- a/meeting-service/src/main/java/com/comeon/meetingservice/web/meetingplace/MeetingPlaceController.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/web/meetingplace/MeetingPlaceController.java
@@ -1,14 +1,18 @@
 package com.comeon.meetingservice.web.meetingplace;
 
+import com.comeon.meetingservice.domain.meetingplace.dto.MeetingPlaceModifyDto;
 import com.comeon.meetingservice.domain.meetingplace.dto.MeetingPlaceSaveDto;
 import com.comeon.meetingservice.domain.meetingplace.service.MeetingPlaceService;
 import com.comeon.meetingservice.web.common.response.ApiResponse;
 import com.comeon.meetingservice.web.common.util.ValidationUtils;
+import com.comeon.meetingservice.web.meetingplace.request.MeetingPlaceModifyRequest;
 import com.comeon.meetingservice.web.meetingplace.request.MeetingPlaceSaveRequest;
+import com.comeon.meetingservice.web.meetingplace.request.PlaceModifyRequestValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.*;
 
 import static org.springframework.http.HttpStatus.*;
@@ -20,6 +24,12 @@ import static org.springframework.http.HttpStatus.*;
 public class MeetingPlaceController {
 
     private final MeetingPlaceService meetingPlaceService;
+    private final PlaceModifyRequestValidator placeModifyRequestValidator;
+
+    @InitBinder("meetingPlaceModifyRequest")
+    public void init(WebDataBinder webDataBinder) {
+        webDataBinder.addValidators(placeModifyRequestValidator);
+    }
 
     @PostMapping
     @ResponseStatus(CREATED)
@@ -32,6 +42,20 @@ public class MeetingPlaceController {
         Long savedId = meetingPlaceService.add(meetingPlaceSaveDto);
 
         return ApiResponse.createSuccess(savedId);
+    }
+
+    @PatchMapping("/{meetingPlaceId}")
+    public ApiResponse meetingPlaceModify(@PathVariable("meetingPlaceId") Long id,
+                                          @Validated @RequestBody MeetingPlaceModifyRequest meetingPlaceModifyRequest,
+                                          BindingResult bindingResult) {
+        ValidationUtils.validate(bindingResult);
+
+        MeetingPlaceModifyDto meetingPlaceModifyDto = meetingPlaceModifyRequest.toDto();
+        meetingPlaceModifyDto.setId(id);
+
+        meetingPlaceService.modify(meetingPlaceModifyDto);
+
+        return ApiResponse.createSuccess();
     }
 
 }

--- a/meeting-service/src/main/java/com/comeon/meetingservice/web/meetingplace/query/MeetingPlaceQueryRepository.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/web/meetingplace/query/MeetingPlaceQueryRepository.java
@@ -1,0 +1,23 @@
+package com.comeon.meetingservice.web.meetingplace.query;
+
+import com.comeon.meetingservice.domain.meeting.entity.QMeetingPlaceEntity;
+import com.comeon.meetingservice.domain.meetingplace.entity.MeetingPlaceEntity;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class MeetingPlaceQueryRepository {
+
+    public final JPAQueryFactory queryFactory;
+
+    public Optional<MeetingPlaceEntity> findById(Long id) {
+        return Optional.ofNullable(queryFactory
+                .selectFrom(QMeetingPlaceEntity.meetingPlaceEntity)
+                .where(QMeetingPlaceEntity.meetingPlaceEntity.id.eq(id))
+                .fetchOne());
+    }
+}

--- a/meeting-service/src/main/java/com/comeon/meetingservice/web/meetingplace/query/MeetingPlaceQueryService.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/web/meetingplace/query/MeetingPlaceQueryService.java
@@ -1,0 +1,23 @@
+package com.comeon.meetingservice.web.meetingplace.query;
+
+import com.comeon.meetingservice.domain.common.exception.EntityNotFoundException;
+import com.comeon.meetingservice.domain.meetingplace.entity.MeetingPlaceEntity;
+import com.comeon.meetingservice.web.meetingplace.response.MeetingPlaceDetailResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MeetingPlaceQueryService {
+
+    private final MeetingPlaceQueryRepository meetingPlaceQueryRepository;
+
+    public MeetingPlaceDetailResponse getDetail(Long id) {
+        MeetingPlaceEntity meetingPlaceEntity = meetingPlaceQueryRepository.findById(id).orElseThrow(() ->
+                new EntityNotFoundException("해당 ID와 일치하는 모임 장소를 찾을 수 없습니다."));
+
+        return MeetingPlaceDetailResponse.toResponse(meetingPlaceEntity);
+    }
+}

--- a/meeting-service/src/main/java/com/comeon/meetingservice/web/meetingplace/request/MeetingPlaceModifyRequest.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/web/meetingplace/request/MeetingPlaceModifyRequest.java
@@ -1,0 +1,33 @@
+package com.comeon.meetingservice.web.meetingplace.request;
+
+import com.comeon.meetingservice.domain.meetingplace.dto.MeetingPlaceModifyDto;
+import lombok.*;
+
+import javax.validation.constraints.NotNull;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter @Setter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+@NoArgsConstructor(access = PRIVATE)
+public class MeetingPlaceModifyRequest {
+
+    private String name;
+    private Double lat;
+    private Double lng;
+
+    private String memo;
+
+    private Integer order;
+
+    public MeetingPlaceModifyDto toDto() {
+        return MeetingPlaceModifyDto.builder()
+                .name(name)
+                .lat(lat)
+                .lng(lng)
+                .memo(memo)
+                .order(order)
+                .build();
+    }
+}

--- a/meeting-service/src/main/java/com/comeon/meetingservice/web/meetingplace/request/MeetingPlaceSaveRequest.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/web/meetingplace/request/MeetingPlaceSaveRequest.java
@@ -1,0 +1,37 @@
+package com.comeon.meetingservice.web.meetingplace.request;
+
+import com.comeon.meetingservice.domain.meetingplace.dto.MeetingPlaceSaveDto;
+import lombok.*;
+
+import javax.validation.constraints.NotNull;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter @Setter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+@NoArgsConstructor(access = PRIVATE)
+public class MeetingPlaceSaveRequest {
+
+    @NotNull
+    private Long meetingId;
+
+    @NotNull
+    private String name;
+
+    @NotNull
+    private Double lat;
+
+    @NotNull
+    private Double lng;
+
+    public MeetingPlaceSaveDto toDto() {
+        return MeetingPlaceSaveDto.builder()
+                .meetingId(meetingId)
+                .name(name)
+                .lat(lat)
+                .lng(lng)
+                .build();
+    }
+
+}

--- a/meeting-service/src/main/java/com/comeon/meetingservice/web/meetingplace/request/PlaceModifyRequestValidator.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/web/meetingplace/request/PlaceModifyRequestValidator.java
@@ -1,0 +1,43 @@
+package com.comeon.meetingservice.web.meetingplace.request;
+
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+
+import java.util.Objects;
+
+@Component
+public class PlaceModifyRequestValidator implements Validator {
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return MeetingPlaceModifyRequest.class.isAssignableFrom(clazz);
+    }
+
+    @Override
+    public void validate(Object target, Errors errors) {
+        MeetingPlaceModifyRequest meetingPlaceModifyRequest = (MeetingPlaceModifyRequest) target;
+
+        // 3개 중 하나라도 null이 아닐 때,
+        if (Objects.nonNull(meetingPlaceModifyRequest.getName())
+                || Objects.nonNull(meetingPlaceModifyRequest.getLat())
+                || Objects.nonNull(meetingPlaceModifyRequest.getLng())) {
+
+            // 3개 중 하나라도 null인 필드가 있다면 예외
+            if (Objects.isNull(meetingPlaceModifyRequest.getName())
+                    || Objects.isNull(meetingPlaceModifyRequest.getLat())
+                    || Objects.isNull(meetingPlaceModifyRequest.getLng())) {
+                errors.reject("requiredAll",
+                        "장소 정보를 수정하기 위해서는 name, lat, lng 3 필드 모두 필요합니다.");
+            }
+        }
+
+        if (Objects.isNull(meetingPlaceModifyRequest.getName())
+                && Objects.isNull(meetingPlaceModifyRequest.getLat())
+                && Objects.isNull(meetingPlaceModifyRequest.getLng())
+                && Objects.isNull(meetingPlaceModifyRequest.getMemo())
+                && Objects.isNull(meetingPlaceModifyRequest.getOrder())) {
+            errors.reject("noModifyingData", "수정하려는 필드가 한 개도 없습니다.");
+        }
+
+    }
+}

--- a/meeting-service/src/main/java/com/comeon/meetingservice/web/meetingplace/response/MeetingPlaceDetailResponse.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/web/meetingplace/response/MeetingPlaceDetailResponse.java
@@ -1,0 +1,30 @@
+package com.comeon.meetingservice.web.meetingplace.response;
+
+import com.comeon.meetingservice.domain.meetingplace.entity.MeetingPlaceEntity;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter @Setter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+@JsonInclude(NON_NULL)
+public class MeetingPlaceDetailResponse {
+
+    private String name;
+    private Double lat;
+    private Double lng;
+
+    public static MeetingPlaceDetailResponse toResponse(MeetingPlaceEntity meetingPlaceEntity) {
+        return MeetingPlaceDetailResponse.builder()
+                .name(meetingPlaceEntity.getName())
+                .lat(meetingPlaceEntity.getLat())
+                .lng(meetingPlaceEntity.getLng())
+                .build();
+    }
+}

--- a/meeting-service/src/test/java/com/comeon/meetingservice/domain/meetingplace/service/MeetingPlaceServiceImplTest.java
+++ b/meeting-service/src/test/java/com/comeon/meetingservice/domain/meetingplace/service/MeetingPlaceServiceImplTest.java
@@ -1,0 +1,149 @@
+package com.comeon.meetingservice.domain.meetingplace.service;
+
+import com.comeon.meetingservice.domain.common.exception.EntityNotFoundException;
+import com.comeon.meetingservice.domain.meeting.entity.MeetingCodeEntity;
+import com.comeon.meetingservice.domain.meeting.entity.MeetingEntity;
+import com.comeon.meetingservice.domain.meeting.entity.MeetingFileEntity;
+import com.comeon.meetingservice.domain.meetingplace.dto.MeetingPlaceSaveDto;
+import com.comeon.meetingservice.domain.meetingplace.entity.MeetingPlaceEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class MeetingPlaceServiceImplTest {
+
+    @Autowired
+    MeetingPlaceService meetingPlaceService;
+
+    @Autowired
+    EntityManager em;
+
+    @Nested
+    @DisplayName("모임 장소 저장 (add)")
+    class 모임장소생성 {
+
+        @Nested
+        @DisplayName("필요한 모든 데이터가 있다면")
+        class 정상흐름 {
+
+            MeetingEntity meetingEntity;
+
+            @BeforeEach
+            public void initMeeting() {
+                MeetingCodeEntity meetingCodeEntity = MeetingCodeEntity.builder()
+                        .inviteCode("aaaaaa")
+                        .expiredDay(7)
+                        .build();
+
+                MeetingFileEntity meetingFileEntity = MeetingFileEntity.builder()
+                        .originalName("ori")
+                        .storedName("sto")
+                        .build();
+
+                meetingEntity = MeetingEntity.builder()
+                        .title("title")
+                        .startDate(LocalDate.now())
+                        .endDate(LocalDate.now().plusDays(7))
+                        .build();
+
+                meetingEntity.addMeetingFileEntity(meetingFileEntity);
+                meetingEntity.addMeetingCodeEntity(meetingCodeEntity);
+
+                em.persist(meetingEntity);
+                em.flush();
+                em.clear();
+            }
+
+            private MeetingPlaceEntity callAddMethodAndFineEntity(MeetingPlaceSaveDto meetingPlaceSaveDto) {
+                Long savedId = meetingPlaceService.add(meetingPlaceSaveDto);
+                em.flush();
+                em.clear();
+
+                return em.find(MeetingPlaceEntity.class, savedId);
+            }
+
+            @Test
+            @DisplayName("모임 장소의 이름, 위도, 경도는 정상적으로 저장이 된다.")
+            public void 모임장소엔티티() throws Exception {
+                // given
+                MeetingPlaceSaveDto meetingPlaceSaveDto = MeetingPlaceSaveDto.builder()
+                        .meetingId(meetingEntity.getId())
+                        .lat(1.1)
+                        .lng(1.2)
+                        .name("장소1")
+                        .build();
+
+                // when
+                MeetingPlaceEntity savedMeetingPlace = callAddMethodAndFineEntity(meetingPlaceSaveDto);
+
+                // then
+                assertThat(savedMeetingPlace.getName()).isEqualTo(meetingPlaceSaveDto.getName());
+                assertThat(savedMeetingPlace.getLat()).isEqualTo(meetingPlaceSaveDto.getLat());
+                assertThat(savedMeetingPlace.getLng()).isEqualTo(meetingPlaceSaveDto.getLng());
+            }
+
+            @Test
+            @DisplayName("모임 장소의 순서는 마지막 장소의 다음 순서로 지정된다.")
+            public void 모임장소순서() throws Exception {
+                // given
+                MeetingPlaceSaveDto meetingPlaceSaveDto1 = MeetingPlaceSaveDto.builder()
+                        .meetingId(meetingEntity.getId())
+                        .lat(1.1)
+                        .lng(1.2)
+                        .name("장소1")
+                        .build();
+
+                MeetingPlaceSaveDto meetingPlaceSaveDto2 = MeetingPlaceSaveDto.builder()
+                        .meetingId(meetingEntity.getId())
+                        .lat(2.1)
+                        .lng(2.2)
+                        .name("장소2")
+                        .build();
+
+                // when
+                MeetingPlaceEntity savedMeetingPlace1 = callAddMethodAndFineEntity(meetingPlaceSaveDto1);
+                MeetingPlaceEntity savedMeetingPlace2 = callAddMethodAndFineEntity(meetingPlaceSaveDto2);
+
+                // then
+                assertThat(savedMeetingPlace1.getOrder()).isEqualTo(1);
+                assertThat(savedMeetingPlace2.getOrder()).isEqualTo(2);
+            }
+        }
+
+        @Nested
+        @DisplayName("필요한 데이터가 유효하지 않는 경우")
+        class 예외 {
+
+            @Test
+            @DisplayName("없는 모임에 장소를 저장하려고 한다면 EntityNotFoundException이 발생한다.")
+            public void 모임예외() throws Exception {
+                // given
+                MeetingPlaceSaveDto meetingPlaceSaveDto = MeetingPlaceSaveDto.builder()
+                        .meetingId(1L)
+                        .lat(1.1)
+                        .lng(1.2)
+                        .name("장소1")
+                        .build();
+
+                // when // then
+                assertThatThrownBy(() -> meetingPlaceService.add(meetingPlaceSaveDto))
+                        .isInstanceOf(EntityNotFoundException.class);
+            }
+        }
+    }
+}

--- a/meeting-service/src/test/java/com/comeon/meetingservice/web/ControllerTest.java
+++ b/meeting-service/src/test/java/com/comeon/meetingservice/web/ControllerTest.java
@@ -1,0 +1,33 @@
+package com.comeon.meetingservice.web;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+@ActiveProfiles("test")
+public abstract class ControllerTest {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    protected String sampleToken = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOjEsIm5hbWUiOiJ0ZXN0Iiw" +
+            "iaWF0IjoxNTE2MjM5MDIyfQ.0u81Gd1qz_yiMpa3WFfCQRKNdGx3OPiMCLm4ceBgbFw";
+    
+    protected String errorCodeLink = "link:common/error-codes.html[예외 코드 참고,role=\"popup\"]";
+
+    protected String createJson(Object dto) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(dto);
+    }
+
+}

--- a/meeting-service/src/test/java/com/comeon/meetingservice/web/meeting/MeetingControllerTest.java
+++ b/meeting-service/src/test/java/com/comeon/meetingservice/web/meeting/MeetingControllerTest.java
@@ -17,6 +17,7 @@ import java.io.FileInputStream;
 
 import static org.hamcrest.Matchers.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
@@ -39,7 +40,7 @@ class MeetingControllerTest extends ControllerTest {
                     ContentType.IMAGE_PNG.getMimeType(),
                     new FileInputStream(file));
 
-            mockMvc.perform(RestDocumentationRequestBuilders.multipart("/meetings")
+            mockMvc.perform(multipart("/meetings")
                             .file(image)
                             .param("title", "타이틀")
                             .param("startDate", "2022-06-10")
@@ -68,7 +69,7 @@ class MeetingControllerTest extends ControllerTest {
         @DisplayName("필수 데이터가 넘어오지 않은 경우")
         public void 모임_저장_파라미터예외() throws Exception {
 
-            mockMvc.perform(RestDocumentationRequestBuilders.multipart("/meetings")
+            mockMvc.perform(multipart("/meetings")
                             .param("title", "타이틀")
                             .header("Authorization", sampleToken)
                     )
@@ -107,7 +108,7 @@ class MeetingControllerTest extends ControllerTest {
                     ContentType.IMAGE_PNG.getMimeType(),
                     new FileInputStream(file));
 
-            mockMvc.perform(RestDocumentationRequestBuilders.multipart("/meetings/{meetingId}", 10)
+            mockMvc.perform(multipart("/meetings/{meetingId}", 10)
                             .file(image)
                             .param("title", "타이틀 변경")
                             .param("startDate", "2022-06-10")
@@ -136,7 +137,7 @@ class MeetingControllerTest extends ControllerTest {
         @DisplayName("이미지를 포함하지 않고 수정할 경우")
         public void 이미지_미포함() throws Exception {
             // given
-            mockMvc.perform(RestDocumentationRequestBuilders.multipart("/meetings/{meetingId}", 10)
+            mockMvc.perform(multipart("/meetings/{meetingId}", 10)
                             .param("title", "타이틀 변경")
                             .param("startDate", "2022-06-10")
                             .param("endDate", "2022-07-10")
@@ -161,7 +162,7 @@ class MeetingControllerTest extends ControllerTest {
         public void 필수값_예외() throws Exception {
             // given
 
-            mockMvc.perform(RestDocumentationRequestBuilders.multipart("/meetings/{meetingId}", 10)
+            mockMvc.perform(multipart("/meetings/{meetingId}", 10)
                             .param("endDate", "2022-07-10")
                             .header("Authorization", sampleToken)
                     )
@@ -185,7 +186,7 @@ class MeetingControllerTest extends ControllerTest {
         public void 경로변수_예외() throws Exception {
             // given
 
-            mockMvc.perform(RestDocumentationRequestBuilders.multipart("/meetings/{meetingId}", 5)
+            mockMvc.perform(multipart("/meetings/{meetingId}", 5)
                             .param("title", "타이틀 변경")
                             .param("startDate", "2022-06-10")
                             .param("endDate", "2022-07-10")
@@ -220,7 +221,7 @@ class MeetingControllerTest extends ControllerTest {
         public void 정상_흐름() throws Exception {
             // given
 
-            mockMvc.perform(RestDocumentationRequestBuilders.delete("/meetings/{meetingId}", 10)
+            mockMvc.perform(delete("/meetings/{meetingId}", 10)
                             .header("Authorization", sampleToken))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
@@ -237,7 +238,7 @@ class MeetingControllerTest extends ControllerTest {
         public void 경로변수_예외() throws Exception {
             // given
 
-            mockMvc.perform(RestDocumentationRequestBuilders.delete("/meetings/{meetingId}", 5)
+            mockMvc.perform(delete("/meetings/{meetingId}", 5)
                             .header("Authorization", sampleToken))
                     .andExpect(status().isBadRequest())
                     .andDo(document("meeting-delete-error-pathvariable",
@@ -259,7 +260,7 @@ class MeetingControllerTest extends ControllerTest {
             String invalidToken = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOjEwLCJuYW1lIjo" +
                     "iSm9obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjJ9.Dd5xvXJhuMekBRlWM8fmdLZjqCUEj_K1dpIvZMaj8-w";
 
-            mockMvc.perform(RestDocumentationRequestBuilders.delete("/meetings/{meetingId}", 10)
+            mockMvc.perform(delete("/meetings/{meetingId}", 10)
                             .header("Authorization", invalidToken))
                     .andExpect(status().isBadRequest())
                     .andDo(document("meeting-delete-error-userid",
@@ -285,7 +286,7 @@ class MeetingControllerTest extends ControllerTest {
         public void 정상_흐름() throws Exception {
             // given
 
-            mockMvc.perform(RestDocumentationRequestBuilders.get("/meetings")
+            mockMvc.perform(get("/meetings")
                             .header("Authorization", sampleToken)
                             .queryParam("page", "0")
                             .queryParam("size", "5")
@@ -331,7 +332,7 @@ class MeetingControllerTest extends ControllerTest {
             // given
             String startDateCond = "2022-07-25";
 
-            mockMvc.perform(RestDocumentationRequestBuilders.get("/meetings")
+            mockMvc.perform(get("/meetings")
                             .header("Authorization", sampleToken)
                             .queryParam("startDate", startDateCond)
                     )
@@ -347,7 +348,7 @@ class MeetingControllerTest extends ControllerTest {
             // given
             String endDateCond = "2022-07-25";
 
-            mockMvc.perform(RestDocumentationRequestBuilders.get("/meetings")
+            mockMvc.perform(get("/meetings")
                             .header("Authorization", sampleToken)
                             .queryParam("endDate", endDateCond)
                     )
@@ -363,7 +364,7 @@ class MeetingControllerTest extends ControllerTest {
             // given
             String titleCond = "2";
 
-            mockMvc.perform(RestDocumentationRequestBuilders.get("/meetings")
+            mockMvc.perform(get("/meetings")
                             .header("Authorization", sampleToken)
                             .queryParam("title", titleCond)
                     )
@@ -385,7 +386,7 @@ class MeetingControllerTest extends ControllerTest {
         public void 정상_흐름() throws Exception {
             // given
 
-            mockMvc.perform(RestDocumentationRequestBuilders.get("/meetings/{meetingId}", 10)
+            mockMvc.perform(get("/meetings/{meetingId}", 10)
                             .header("Authorization", sampleToken)
                     )
                     .andExpect(status().isOk())
@@ -428,7 +429,7 @@ class MeetingControllerTest extends ControllerTest {
         public void 경로변수_예외() throws Exception {
             // given
 
-            mockMvc.perform(RestDocumentationRequestBuilders.get("/meetings/{meetingId}", 5)
+            mockMvc.perform(get("/meetings/{meetingId}", 5)
                             .header("Authorization", sampleToken)
                     )
                     .andExpect(status().isBadRequest())

--- a/meeting-service/src/test/java/com/comeon/meetingservice/web/meeting/MeetingControllerTest.java
+++ b/meeting-service/src/test/java/com/comeon/meetingservice/web/meeting/MeetingControllerTest.java
@@ -1,20 +1,15 @@
 package com.comeon.meetingservice.web.meeting;
 
+import com.comeon.meetingservice.web.ControllerTest;
 import org.apache.http.entity.ContentType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.util.ResourceUtils;
 
 import java.io.File;
@@ -29,17 +24,7 @@ import static org.springframework.restdocs.snippet.Attributes.key;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@SpringBootTest
-@AutoConfigureMockMvc
-@AutoConfigureRestDocs
-@ActiveProfiles("test")
-class MeetingControllerTest {
-
-    @Autowired
-    MockMvc mockMvc;
-
-    String sampleToken = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOjEsIm5hbWUiOiJ0ZXN0Iiw" +
-            "iaWF0IjoxNTE2MjM5MDIyfQ.0u81Gd1qz_yiMpa3WFfCQRKNdGx3OPiMCLm4ceBgbFw";
+class MeetingControllerTest extends ControllerTest {
 
     @Nested
     @DisplayName("모임 저장")
@@ -96,7 +81,7 @@ class MeetingControllerTest {
                                     parameterWithName("courseId").description("장소를 참조할 코스의 ID").optional()
                             ),
                             responseFields(beneathPath("data").withSubsectionId("data"),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("link:common/error-codes.html[예외 코드 참고,role=\"popup\"]"),
+                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                     fieldWithPath("message").type(JsonFieldType.STRING).description("어떤 파라미터가 넘어오지 않았는지 표시")
                             ))
                     )
@@ -188,7 +173,7 @@ class MeetingControllerTest {
                                     parameterWithName("endDate").description("수정할 종료일").attributes(key("format").value("yyyy-MM-dd"))
                             ),
                             responseFields(beneathPath("data").withSubsectionId("data"),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("link:common/error-codes.html[예외 코드 참고,role=\"popup\"]"),
+                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                     fieldWithPath("message").type(JsonFieldType.STRING).description("어떤 파라미터가 넘어오지 않았는지 표시")
                             ))
                     )
@@ -216,7 +201,7 @@ class MeetingControllerTest {
                                     parameterWithName("endDate").description("수정할 종료일").attributes(key("format").value("yyyy-MM-dd"))
                             ),
                             responseFields(beneathPath("data").withSubsectionId("data"),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("link:common/error-codes.html[예외 코드 참고,role=\"popup\"]"),
+                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                     fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                             ))
                     )
@@ -259,7 +244,7 @@ class MeetingControllerTest {
                             preprocessRequest(prettyPrint()),
                             preprocessResponse(prettyPrint()),
                             responseFields(beneathPath("data").withSubsectionId("data"),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("link:common/error-codes.html[예외 코드 참고,role=\"popup\"]"),
+                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                     fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                             ))
                     )
@@ -281,7 +266,7 @@ class MeetingControllerTest {
                             preprocessRequest(prettyPrint()),
                             preprocessResponse(prettyPrint()),
                             responseFields(beneathPath("data").withSubsectionId("data"),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("link:common/error-codes.html[예외 코드 참고,role=\"popup\"]"),
+                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                     fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                             ))
                     )
@@ -452,7 +437,7 @@ class MeetingControllerTest {
                             preprocessRequest(prettyPrint()),
                             preprocessResponse(prettyPrint()),
                             responseFields(beneathPath("data").withSubsectionId("data"),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("link:common/error-codes.html[예외 코드 참고,role=\"popup\"]"),
+                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                     fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                             ))
                     )

--- a/meeting-service/src/test/java/com/comeon/meetingservice/web/meetingplace/MeetingPlaceControllerTest.java
+++ b/meeting-service/src/test/java/com/comeon/meetingservice/web/meetingplace/MeetingPlaceControllerTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.request.RequestDocumentation;
 import org.springframework.test.context.jdbc.Sql;
 
 import java.util.HashMap;
@@ -357,6 +358,56 @@ class MeetingPlaceControllerTest extends ControllerTest {
                     .andExpect(status().isBadRequest())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                     .andDo(document("place-delete-error-pathvariable",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            responseFields(beneathPath("data").withSubsectionId("data"),
+                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                    fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
+                            ))
+                    )
+            ;
+        }
+    }
+
+    @Nested
+    @DisplayName("모임조회 - 단건")
+    class 모임단건조회 {
+
+        @Test
+        @DisplayName("정상적으로 조회될 경우")
+        @Sql(value = "classpath:static/test-dml/meeting-insert.sql", executionPhase = BEFORE_TEST_METHOD)
+        @Sql(value = "classpath:static/test-dml/meeting-delete.sql", executionPhase = AFTER_TEST_METHOD)
+        public void 정상_흐름() throws Exception {
+
+            mockMvc.perform(get("/meeting-places/{meetingPlaceId}", 10)
+                            .header("Authorization", sampleToken)
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                    .andDo(document("place-detail-normal",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            responseFields(beneathPath("data").withSubsectionId("data"),
+                                    fieldWithPath("name").type(JsonFieldType.STRING).description("모임 장소의 이름"),
+                                    fieldWithPath("lat").type(JsonFieldType.NUMBER).description("모임 장소의 위도"),
+                                    fieldWithPath("lng").type(JsonFieldType.NUMBER).description("모임 장소의 경도")
+                            ))
+                    )
+            ;
+        }
+
+        @Test
+        @DisplayName("없는 장소를 조회하려 할 경우")
+        @Sql(value = "classpath:static/test-dml/meeting-insert.sql", executionPhase = BEFORE_TEST_METHOD)
+        @Sql(value = "classpath:static/test-dml/meeting-delete.sql", executionPhase = AFTER_TEST_METHOD)
+        public void 경로변수_예외() throws Exception {
+
+            mockMvc.perform(get("/meeting-places/{meetingPlaceId}", 5)
+                            .header("Authorization", sampleToken)
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                    .andDo(document("place-detail-error-pathvariable",
                             preprocessRequest(prettyPrint()),
                             preprocessResponse(prettyPrint()),
                             responseFields(beneathPath("data").withSubsectionId("data"),

--- a/meeting-service/src/test/java/com/comeon/meetingservice/web/meetingplace/MeetingPlaceControllerTest.java
+++ b/meeting-service/src/test/java/com/comeon/meetingservice/web/meetingplace/MeetingPlaceControllerTest.java
@@ -1,0 +1,136 @@
+package com.comeon.meetingservice.web.meetingplace;
+
+import com.comeon.meetingservice.web.ControllerTest;
+import com.comeon.meetingservice.web.meetingplace.request.MeetingPlaceSaveRequest;
+import org.apache.http.entity.ContentType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class MeetingPlaceControllerTest extends ControllerTest {
+
+    @Nested
+    @DisplayName("모임장소 저장")
+    class 모임장소저장 {
+
+        @Test
+        @DisplayName("모든 필수 데이터가 넘어온 경우 Created코드와 저장된 ID를 응답한다.")
+        @Sql(value = "classpath:static/test-dml/meeting-insert.sql", executionPhase = BEFORE_TEST_METHOD)
+        @Sql(value = "classpath:static/test-dml/meeting-delete.sql", executionPhase = AFTER_TEST_METHOD)
+        public void 정상_흐름() throws Exception {
+
+            MeetingPlaceSaveRequest meetingPlaceSaveRequest =
+                    MeetingPlaceSaveRequest.builder()
+                            .meetingId(10L)
+                            .name("모임장소이름")
+                            .lat(1.1)
+                            .lng(1.1)
+                            .build();
+
+            mockMvc.perform(RestDocumentationRequestBuilders.post("/meeting-places")
+                            .header("Authorization", sampleToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(createJson(meetingPlaceSaveRequest))
+                    )
+                    .andExpect(status().isCreated())
+                    .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                    .andDo(document("place-create-normal",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestFields(
+                                    fieldWithPath("meetingId").description("장소를 추가할 모임의 ID"),
+                                    fieldWithPath("name").description("추가할 장소의 이름"),
+                                    fieldWithPath("lat").description("추가할 장소의 위도"),
+                                    fieldWithPath("lng").description("추가할 장소의 경도")
+                            ))
+                    )
+            ;
+        }
+
+        @Test
+        @DisplayName("없는 모임 ID일 경우 BadRequest와 예외 정보가 응답된다.")
+        @Sql(value = "classpath:static/test-dml/meeting-insert.sql", executionPhase = BEFORE_TEST_METHOD)
+        @Sql(value = "classpath:static/test-dml/meeting-delete.sql", executionPhase = AFTER_TEST_METHOD)
+        public void 파라미터_예외() throws Exception {
+
+            MeetingPlaceSaveRequest meetingPlaceSaveRequest =
+                    MeetingPlaceSaveRequest.builder()
+                            .meetingId(5L)
+                            .name("모임장소이름")
+                            .lat(1.1)
+                            .lng(1.1)
+                            .build();
+
+            mockMvc.perform(RestDocumentationRequestBuilders.post("/meeting-places")
+                            .header("Authorization", sampleToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(createJson(meetingPlaceSaveRequest))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                    .andDo(document("place-create-error-meetingid",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestFields(
+                                    fieldWithPath("meetingId").description("장소를 추가할 모임의 ID"),
+                                    fieldWithPath("name").description("추가할 장소의 이름"),
+                                    fieldWithPath("lat").description("추가할 장소의 위도"),
+                                    fieldWithPath("lng").description("추가할 장소의 경도")
+                            ),
+                            responseFields(beneathPath("data").withSubsectionId("data"),
+                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                    fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
+                            ))
+                            
+                    )
+            ;
+        }
+
+        @Test
+        @DisplayName("필수 값이 없을 경우 BadRequest와 예외 정보가 응답된다.")
+        @Sql(value = "classpath:static/test-dml/meeting-insert.sql", executionPhase = BEFORE_TEST_METHOD)
+        @Sql(value = "classpath:static/test-dml/meeting-delete.sql", executionPhase = AFTER_TEST_METHOD)
+        public void 필수값_예외() throws Exception {
+
+            Map<String, Long> dummyContents = new HashMap<>();
+            dummyContents.put("meetingId", 10L);
+
+            mockMvc.perform(RestDocumentationRequestBuilders.post("/meeting-places")
+                            .header("Authorization", sampleToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(createJson(dummyContents))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                    .andDo(document("place-create-error-param",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestFields(
+                                    fieldWithPath("meetingId").description("장소를 추가할 모임의 ID")
+                            ),
+                            responseFields(beneathPath("data").withSubsectionId("data"),
+                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                    fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
+                            ))
+
+                    )
+            ;
+        }
+    }
+}

--- a/meeting-service/src/test/java/com/comeon/meetingservice/web/meetingplace/MeetingPlaceControllerTest.java
+++ b/meeting-service/src/test/java/com/comeon/meetingservice/web/meetingplace/MeetingPlaceControllerTest.java
@@ -320,7 +320,51 @@ class MeetingPlaceControllerTest extends ControllerTest {
                         )
                 ;
             }
+        }
+    }
 
+    @Nested
+    @DisplayName("모임장소 삭제")
+    class 모임장소삭제 {
+
+        @Test
+        @DisplayName("정상적으로 삭제될 경우")
+        @Sql(value = "classpath:static/test-dml/meeting-insert.sql", executionPhase = BEFORE_TEST_METHOD)
+        @Sql(value = "classpath:static/test-dml/meeting-delete.sql", executionPhase = AFTER_TEST_METHOD)
+        public void 정상_흐름() throws Exception {
+
+            mockMvc.perform(delete("/meeting-places/{meetingPlaceId}", 10)
+                            .header("Authorization", sampleToken)
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                    .andDo(document("place-delete-normal",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint())
+                    ))
+            ;
+        }
+
+        @Test
+        @DisplayName("없는 장소를 삭제하려 할 경우")
+        @Sql(value = "classpath:static/test-dml/meeting-insert.sql", executionPhase = BEFORE_TEST_METHOD)
+        @Sql(value = "classpath:static/test-dml/meeting-delete.sql", executionPhase = AFTER_TEST_METHOD)
+        public void 경로변수_예외() throws Exception {
+
+            mockMvc.perform(delete("/meeting-places/{meetingPlaceId}", 5)
+                            .header("Authorization", sampleToken)
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                    .andDo(document("place-delete-error-pathvariable",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            responseFields(beneathPath("data").withSubsectionId("data"),
+                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                    fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
+                            ))
+                    )
+            ;
         }
     }
 }

--- a/meeting-service/src/test/resources/static/test-dml/meeting-insert.sql
+++ b/meeting-service/src/test/resources/static/test-dml/meeting-insert.sql
@@ -14,9 +14,9 @@ insert into meeting_image (id, created_date_time, modified_date_time, original_n
 insert into meeting (id, created_date_time, modified_date_time, end_date, meeting_code_id, meeting_file_id, start_date, title) values (12, '2022-08-15T12:13:59.101', '2022-08-15T12:13:59.101', '2022-08-10', 12, 12, '2022-07-30', 'title3');
 insert into user_meeting (id, created_date_time, modified_date_time, image_link, meeting_id, meeting_role, nick_name, user_id) values (default, '2022-08-18T13:44:52.804', '2022-08-18T13:44:52.804', 'link4', 12, 'HOST', 'nickname4', 1);
 
-insert into meeting_place (id, created_date_time, modified_date_time, lat, lng, meeting_id, memo, name, orders) values (default, '2022-08-18T13:44:52.860', '2022-08-18T13:44:52.860', 1.1, 1.1, 10, 'memo1', 'name1', 3);
-insert into meeting_place (id, created_date_time, modified_date_time, lat, lng, meeting_id, memo, name, orders) values (default, '2022-08-18T13:44:52.863', '2022-08-18T13:44:52.863', 2.1, 2.1, 10, 'memo2', 'name2', 2);
-insert into meeting_place (id, created_date_time, modified_date_time, lat, lng, meeting_id, memo, name, orders) values (default, '2022-08-18T13:44:52.865', '2022-08-18T13:44:52.865', 3.1, 3.1, 10, 'memo3', 'name3', 1);
+insert into meeting_place (id, created_date_time, modified_date_time, lat, lng, meeting_id, memo, name, orders) values (10, '2022-08-18T13:44:52.860', '2022-08-18T13:44:52.860', 1.1, 1.1, 10, 'memo1', 'name1', 3);
+insert into meeting_place (id, created_date_time, modified_date_time, lat, lng, meeting_id, memo, name, orders) values (11, '2022-08-18T13:44:52.863', '2022-08-18T13:44:52.863', 2.1, 2.1, 10, 'memo2', 'name2', 2);
+insert into meeting_place (id, created_date_time, modified_date_time, lat, lng, meeting_id, memo, name, orders) values (12, '2022-08-18T13:44:52.865', '2022-08-18T13:44:52.865', 3.1, 3.1, 10, 'memo3', 'name3', 1);
 
 insert into meeting_date (id, created_date_time, modified_date_time, date, meeting_id, user_count) values (default, '2022-08-18T13:44:52.860', '2022-08-18T13:44:52.860', '2022-07-20', 10, 1);
 insert into meeting_date (id, created_date_time, modified_date_time, date, meeting_id, user_count) values (default, '2022-08-18T13:44:52.863', '2022-08-18T13:44:52.863', '2022-07-15', 10, 2);


### PR DESCRIPTION
모임 장소 도메인을 전반적으로 개발하였습니다. 

- 모임 장소 추가 기능

- 모임 장소 수정 기능
   - 모임 장소 수정/삭제 시 순서 변경 로직을 작성했는데 검토 부탁드립니다.
   - 모임 장소 정보 수정 시 객체 검증 Validator를 추가했습니다. name, lat, lng 3개의 필드가 모두 채워져 있거나, 모두 비워져 있으면 검증에 통과하는데 이 로직 검토 부탁드립니다.

- 모임 장소 삭제 기능
- 모임 장소 단건 조회 기능

