### PR TITLE
Feature/course service

### DIFF
--- a/course-service/build.gradle
+++ b/course-service/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'org.springframework.boot' version '2.7.2'
     id 'io.spring.dependency-management' version '1.0.12.RELEASE'
     id 'java'
+    id "org.asciidoctor.jvm.convert" version "3.3.2"
 }
 
 group = 'com.comeon'
@@ -9,6 +10,7 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
 configurations {
+    asciidoctorExtensions
     compileOnly {
         extendsFrom annotationProcessor
     }
@@ -30,13 +32,33 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.cloud:spring-cloud-starter-bus-amqp'
-
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // test lombok
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+
+    // rest docs
+    asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
+    // aws
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    testImplementation 'io.findify:s3mock_2.13:0.2.6'
+
+    // aop
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+
+    // jwt for test
+    testImplementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+    testImplementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
+    testImplementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
 }
 
 dependencyManagement {
@@ -45,6 +67,35 @@ dependencyManagement {
     }
 }
 
+ext {
+    snippetsDir = file('build/generated-snippets')
+}
+
 tasks.named('test') {
     useJUnitPlatform()
+    outputs.dir snippetsDir
+}
+
+asciidoctor {
+    configurations 'asciidoctorExtensions'
+    inputs.dir snippetsDir
+    dependsOn test
+
+    sources{
+        include('**/index.adoc','**/common/*.adoc')
+    }
+}
+
+asciidoctor.doFirst {
+    delete file('src/main/resources/static/docs')
+}
+
+task copyDocument(type: Copy) {
+    dependsOn asciidoctor
+    from file("build/docs/asciidoc")
+    into file("src/main/resources/static/docs")
+}
+
+build {
+    dependsOn copyDocument
 }

--- a/course-service/src/docs/asciidoc/index.adoc
+++ b/course-service/src/docs/asciidoc/index.adoc
@@ -50,7 +50,7 @@ include::{snippets}/common-response-rest-docs-test/error-code/common-response-fi
 
 POST /courses
 
-[[Normal]]
+[[Course-save-Normal]]
 === 1) 정상 흐름
 
 ==== 요청 예시
@@ -77,7 +77,7 @@ include::{snippets}/course-save/success/http-response.adoc[]
 include::{snippets}/course-save/success/response-fields-data.adoc[]
 
 
-[[Error]]
+[[Course-save-Error]]
 === 2) 예외
 
 ==== 요청 예시
@@ -95,55 +95,6 @@ include::{snippets}/course-save/validation-fail/http-response.adoc[]
 include::{snippets}/course-save/validation-fail/response-fields-data.adoc[]
 
 
-[[Course-Writing-Done]]
-== 2. 코스 등록 완료
-
-PATCH /courses/{courseId}/done
-
-[[Normal]]
-=== 1) 정상 흐름
-
-==== 요청 예시
-다음과 같이, 요청한 유저가 등록한 코스의 식별자를 경로 변수로 전송하면, 요청을 성공적으로 처리합니다.
-
-include::{snippets}/course-writing-done/success/http-request.adoc[]
-
-==== 요청 헤더
-
-include::{snippets}/course-writing-done/success/request-headers.adoc[]
-
-==== 요청 경로 파라미터
-
-include::{snippets}/course-writing-done/success/path-parameters.adoc[]
-
-==== 응답 예시
-요청을 성공적으로 처리하면 다음과 같은 응답을 반환합니다.
-
-include::{snippets}/course-writing-done/success/http-response.adoc[]
-
-==== 응답 필드
-include::{snippets}/course-writing-done/success/response-fields-data.adoc[]
-
-
-[[Error]]
-=== 2) 예외
-
-==== 요청 예시
-다음과 같이, 경로 변수 ``{courseId}``로 존재하지 않는 코스의 식별자가 넘어오면 +
-예외가 발생하여 요청이 처리되지 않습니다.
-
-include::{snippets}/course-writing-done/fail-entity-not-found/http-request.adoc[]
-
-==== 응답 예시
-해당 예외가 발생하여 요청이 실패하면, 다음과 같은 응답을 반환합니다.
-
-include::{snippets}/course-writing-done/fail-entity-not-found/http-response.adoc[]
-
-==== 응답 필드
-
-include::{snippets}/course-writing-done/fail-entity-not-found/response-fields-data.adoc[]
-
-
 '''
 = 코스 장소
 
@@ -152,7 +103,7 @@ include::{snippets}/course-writing-done/fail-entity-not-found/response-fields-da
 
 POST /course-place
 
-[[Normal]]
+[[Course-Place-Save-Normal]]
 === 1) 정상 흐름
 
 ==== 요청 예시
@@ -177,7 +128,7 @@ include::{snippets}/course-place-save/success/http-response.adoc[]
 include::{snippets}/course-place-save/success/response-fields-data.adoc[]
 
 
-[[Error]]
+[[Course-Place-Save-Error]]
 === 2) 예외
 
 ==== 요청 예시
@@ -193,3 +144,64 @@ include::{snippets}/course-place-save/fail/http-response.adoc[]
 ==== 응답 필드
 
 include::{snippets}/course-place-save/fail/response-fields-data.adoc[]
+
+
+'''
+[[Course-Place-Save-Batch]]
+== 2. 코스 장소 리스트 등록
+
+POST /course-place/batch
+
+[[Course-Place-Save-Batch-Normal]]
+=== 1) 정상 흐름
+
+==== 요청 예시
+다음과 같이, 필수 데이터들을 모두 포함하여 요청하면, 요청을 성공적으로 처리하고 응답을 반환합니다.
+
+include::{snippets}/course-place-save-batch/success/http-request.adoc[]
+
+==== 요청 헤더
+
+include::{snippets}/course-place-save-batch/success/request-headers.adoc[]
+
+==== 요청 파라미터
+
+include::{snippets}/course-place-save-batch/success/request-fields.adoc[]
+
+==== 응답 예시
+요청을 성공적으로 처리하면 다음과 같은 응답을 반환합니다.
+
+include::{snippets}/course-place-save-batch/success/http-response.adoc[]
+
+==== 응답 필드
+include::{snippets}/course-place-save-batch/success/response-fields-data.adoc[]
+
+
+[[Course-Place-Save-Batch-Error]]
+=== 2) 예외
+
+==== 요청 예시 1
+다음과 같이 필수 데이터인 장소를 하나도 전송하지 않으면
+예외가 발생하여 요청이 처리되지 않습니다.
+
+include::{snippets}/course-place-save-batch/fail-all-field/http-request.adoc[]
+
+==== 응답 예시 1
+요청 데이터 검증에 실패하면 다음과 같은 응답을 반환합니다.
+
+include::{snippets}/course-place-save-batch/fail-all-field/http-response.adoc[]
+
+==== 요청 예시 2
+다음과 같이, 장소 리스트 중 특정 필드를 입력하지 않은 경우,
+예외가 발생하여 요청이 처리되지 않습니다.
+
+include::{snippets}/course-place-save-batch/fail-specific-field/http-request.adoc[]
+
+==== 응답 예시 2
+요청 데이터 검증에 실패하면 다음과 같은 응답을 반환합니다.
+
+include::{snippets}/course-place-save-batch/fail-specific-field/http-response.adoc[]
+
+==== 응답 필드
+
+include::{snippets}/course-place-save-batch/fail-all-field/response-fields-data.adoc[]

--- a/course-service/src/docs/asciidoc/index.adoc
+++ b/course-service/src/docs/asciidoc/index.adoc
@@ -1,0 +1,195 @@
+
+= Course Service API Docs
+:toc-title: Course-Service API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+[[common]]
+== 공통 스펙
+
+==== 공통 응답 스펙
+include::{snippets}/common-response-rest-docs-test/common-response/common-response-fields.adoc[]
+
+Course-Service 응답메시지는 모두 위와 같은 스펙으로 구성되어 있습니다.
+
+===== code field : 응답 코드 반환값
+
+include::{snippets}/common-response-rest-docs-test/common-response/common-response-fields-code.adoc[]
+
+공통 응답 스펙의 ``code`` 필드에는 위와 같은 값들이 반환될 수 있습니다. +
+응답 코드는 ``SUCCESS``인 경우를 제외하고 모두 예외가 발생한 상황입니다.
+
+==== 공통 응답 스펙 - 예외인 경우
+
+include::{snippets}/common-response-rest-docs-test/error-response/common-response-fields-error.adoc[]
+
+예외가 발생한 경우에는 `data` 필드에 위와 같은 형식으로 발생한 예외에 대한 응답이 들어갑니다. +
+아래의 예시를 참고해주세요.
+
+include::{snippets}/common-response-rest-docs-test/error-response/response-body.adoc[]
+
+// TODO 문서 수정 필요
+===== errorCode field : 예외 응답 코드 반환값
+
+include::{snippets}/common-response-rest-docs-test/error-code/common-response-fields-error-codes.adoc[]
+
+예외 응답 스펙의 ``code`` 필드에는 위와 같은 값들이 반환될 수 있습니다.
+
+= 코스
+
+[[Course-save]]
+== 1. 코스 등록
+
+POST /courses
+
+[[Normal]]
+=== 1) 정상 흐름
+
+==== 요청 예시
+다음과 같이, 필수 데이터들을 모두 담아 요청하면, 요청을 성공적으로 처리하고 응답을 반환합니다.
+
+include::{snippets}/course-save/success/http-request.adoc[]
+
+==== 요청 헤더
+
+include::{snippets}/course-save/success/request-headers.adoc[]
+
+==== 요청 파라미터
+
+include::{snippets}/course-save/success/request-parameters.adoc[]
+include::{snippets}/course-save/success/request-parts.adoc[]
+
+
+==== 응답 예시
+요청을 성공적으로 처리하면 다음과 같은 응답을 반환합니다.
+
+include::{snippets}/course-save/success/http-response.adoc[]
+
+==== 응답 필드
+include::{snippets}/course-save/success/response-fields-data.adoc[]
+
+
+[[Error]]
+=== 2) 예외
+
+==== 요청 예시
+다음과 같이 필수 데이터를 전송하지 않으면 예외가 발생하여 요청이 처리되지 않습니다.
+
+include::{snippets}/course-save/validation-fail/http-request.adoc[]
+
+==== 응답 예시
+요청 데이터 검증에 실패하면 다음과 같은 응답을 반환합니다.
+
+include::{snippets}/course-save/validation-fail/http-response.adoc[]
+
+==== 응답 필드
+
+include::{snippets}/course-save/validation-fail/response-fields-data.adoc[]
+
+
+[[Course-Writing-Done]]
+== 2. 코스 등록 완료
+
+PATCH /courses/{courseId}/done
+
+[[Normal]]
+=== 1) 정상 흐름
+
+==== 요청 예시
+다음과 같이, 요청한 유저가 등록한 코스의 식별자를 경로 변수로 전송하면, 요청을 성공적으로 처리합니다.
+
+include::{snippets}/course-writing-done/success/http-request.adoc[]
+
+==== 요청 헤더
+
+include::{snippets}/course-writing-done/success/request-headers.adoc[]
+
+==== 요청 경로 파라미터
+
+include::{snippets}/course-writing-done/success/path-parameters.adoc[]
+
+==== 응답 예시
+요청을 성공적으로 처리하면 다음과 같은 응답을 반환합니다.
+
+include::{snippets}/course-writing-done/success/http-response.adoc[]
+
+==== 응답 필드
+include::{snippets}/course-writing-done/success/response-fields-data.adoc[]
+
+
+[[Error]]
+=== 2) 예외
+
+==== 요청 예시
+다음과 같이, 경로 변수 ``{courseId}``로 존재하지 않는 코스의 식별자가 넘어오면 +
+예외가 발생하여 요청이 처리되지 않습니다.
+
+include::{snippets}/course-writing-done/fail-entity-not-found/http-request.adoc[]
+
+==== 응답 예시
+해당 예외가 발생하여 요청이 실패하면, 다음과 같은 응답을 반환합니다.
+
+include::{snippets}/course-writing-done/fail-entity-not-found/http-response.adoc[]
+
+==== 응답 필드
+
+include::{snippets}/course-writing-done/fail-entity-not-found/response-fields-data.adoc[]
+
+
+'''
+= 코스 장소
+
+[[Course-Place-Save]]
+== 1. 코스 장소 등록
+
+POST /course-place
+
+[[Normal]]
+=== 1) 정상 흐름
+
+==== 요청 예시
+다음과 같이, 필수 데이터들을 모두 포함하여 요청하면, 요청을 성공적으로 처리하고 응답을 반환합니다.
+
+include::{snippets}/course-place-save/success/http-request.adoc[]
+
+==== 요청 헤더
+
+include::{snippets}/course-place-save/success/request-headers.adoc[]
+
+==== 요청 파라미터
+
+include::{snippets}/course-place-save/success/request-fields.adoc[]
+
+==== 응답 예시
+요청을 성공적으로 처리하면 다음과 같은 응답을 반환합니다.
+
+include::{snippets}/course-place-save/success/http-response.adoc[]
+
+==== 응답 필드
+include::{snippets}/course-place-save/success/response-fields-data.adoc[]
+
+
+[[Error]]
+=== 2) 예외
+
+==== 요청 예시
+다음과 같이 필수 데이터를 전송하지 않으면 예외가 발생하여 요청이 처리되지 않습니다.
+
+include::{snippets}/course-place-save/fail/http-request.adoc[]
+
+==== 응답 예시
+요청 데이터 검증에 실패하면 다음과 같은 응답을 반환합니다.
+
+include::{snippets}/course-place-save/fail/http-response.adoc[]
+
+==== 응답 필드
+
+include::{snippets}/course-place-save/fail/response-fields-data.adoc[]

--- a/course-service/src/main/java/com/comeon/courseservice/CourseServiceApplication.java
+++ b/course-service/src/main/java/com/comeon/courseservice/CourseServiceApplication.java
@@ -3,7 +3,9 @@ package com.comeon.courseservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 @EnableDiscoveryClient
 public class CourseServiceApplication {

--- a/course-service/src/main/java/com/comeon/courseservice/common/exception/CustomException.java
+++ b/course-service/src/main/java/com/comeon/courseservice/common/exception/CustomException.java
@@ -1,0 +1,29 @@
+package com.comeon.courseservice.common.exception;
+
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    public CustomException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public CustomException(String message, Throwable cause, ErrorCode errorCode) {
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+
+    public CustomException(Throwable cause, ErrorCode errorCode) {
+        super(cause);
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/course-service/src/main/java/com/comeon/courseservice/common/exception/ErrorCode.java
+++ b/course-service/src/main/java/com/comeon/courseservice/common/exception/ErrorCode.java
@@ -1,0 +1,28 @@
+package com.comeon.courseservice.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+public enum ErrorCode {
+    SERVER_ERROR(900, INTERNAL_SERVER_ERROR, "죄송합니다. 서버 내부 오류입니다."),
+    EMPTY_FILE(901, BAD_REQUEST, "파일이 비어있습니다. 확인해주세요."),
+    UPLOAD_FAIL(902, INTERNAL_SERVER_ERROR, "파일 업로드에 실패하였습니다."),
+    VALIDATION_FAIL(903, BAD_REQUEST, "요청 데이터 검증에 실패하였습니다."),
+    ENTITY_NOT_FOUND(904, BAD_REQUEST, "해당 식별자를 가진 리소스가 없습니다."),
+    NO_AUTHORITIES(905, FORBIDDEN, "요청을 수행할 권한이 없습니다."),
+    NO_ACCESS_TOKEN(907, UNAUTHORIZED, "인증된 사용자만이 이용 가능합니다."),
+    ;
+
+    private final Integer code;
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    ErrorCode(Integer code, HttpStatus httpStatus, String message) {
+        this.code = code;
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+}

--- a/course-service/src/main/java/com/comeon/courseservice/config/WebConfig.java
+++ b/course-service/src/main/java/com/comeon/courseservice/config/WebConfig.java
@@ -1,0 +1,29 @@
+package com.comeon.courseservice.config;
+
+import com.comeon.courseservice.config.argresolver.JwtArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.DefaultMessageCodesResolver;
+import org.springframework.validation.MessageCodesResolver;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final JwtArgumentResolver jwtArgumentResolver;
+
+    @Bean
+    public MessageCodesResolver messageCodesResolver() {
+        return new DefaultMessageCodesResolver();
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(jwtArgumentResolver);
+    }
+}

--- a/course-service/src/main/java/com/comeon/courseservice/config/argresolver/CurrentUserId.java
+++ b/course-service/src/main/java/com/comeon/courseservice/config/argresolver/CurrentUserId.java
@@ -1,0 +1,12 @@
+package com.comeon.courseservice.config.argresolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUserId {
+}
+

--- a/course-service/src/main/java/com/comeon/courseservice/config/argresolver/JwtArgumentResolver.java
+++ b/course-service/src/main/java/com/comeon/courseservice/config/argresolver/JwtArgumentResolver.java
@@ -1,0 +1,68 @@
+package com.comeon.courseservice.config.argresolver;
+
+import com.comeon.courseservice.common.exception.CustomException;
+import com.comeon.courseservice.common.exception.ErrorCode;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Base64;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class JwtArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Value("${token.claim-name.user-id}")
+    private String userIdClaimName;
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasUserIdAnnotation = parameter.hasParameterAnnotation(CurrentUserId.class);
+        boolean isLongType = Long.class.isAssignableFrom(parameter.getParameterType());
+        return hasUserIdAnnotation && isLongType;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        String accessToken = resolveAccessToken(request);
+        return getUserId(accessToken);
+    }
+
+    private String resolveAccessToken(HttpServletRequest request) {
+        String token = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (!(StringUtils.hasText(token) && token.startsWith("Bearer "))) {
+            throw new CustomException("인증 헤더에서 엑세스 토큰을 확인할 수 없습니다.", ErrorCode.NO_ACCESS_TOKEN);
+        }
+        return token.substring(7);
+    }
+
+    private Long getUserId(String accessToken) {
+        Base64.Decoder urlDecoder = Base64.getUrlDecoder();
+        String payload = new String(urlDecoder.decode(accessToken.split("\\.")[1]));
+        Map<String, Object> payloadObject = null;
+        try {
+            payloadObject = objectMapper.readValue(payload, new TypeReference<Map<String, Object>>() {});
+        } catch (JsonProcessingException e) {
+            throw new CustomException("토큰 파싱 오류 발생", e, ErrorCode.SERVER_ERROR);
+        }
+        return Long.parseLong((String) payloadObject.get(userIdClaimName));
+    }
+}

--- a/course-service/src/main/java/com/comeon/courseservice/domain/common/BaseTimeEntity.java
+++ b/course-service/src/main/java/com/comeon/courseservice/domain/common/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package com.comeon.courseservice.domain.common;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedDate;
+}

--- a/course-service/src/main/java/com/comeon/courseservice/domain/common/exception/EntityNotFoundException.java
+++ b/course-service/src/main/java/com/comeon/courseservice/domain/common/exception/EntityNotFoundException.java
@@ -1,0 +1,25 @@
+package com.comeon.courseservice.domain.common.exception;
+
+import com.comeon.courseservice.common.exception.CustomException;
+import com.comeon.courseservice.common.exception.ErrorCode;
+
+public class EntityNotFoundException extends CustomException {
+
+    private static final ErrorCode ERROR_CODE_ENTITY_NOT_FOUND = ErrorCode.ENTITY_NOT_FOUND;
+
+    public EntityNotFoundException() {
+        super(ERROR_CODE_ENTITY_NOT_FOUND);
+    }
+
+    public EntityNotFoundException(String message) {
+        super(message, ERROR_CODE_ENTITY_NOT_FOUND);
+    }
+
+    public EntityNotFoundException(String message, Throwable cause) {
+        super(message, cause, ERROR_CODE_ENTITY_NOT_FOUND);
+    }
+
+    public EntityNotFoundException(Throwable cause) {
+        super(cause, ERROR_CODE_ENTITY_NOT_FOUND);
+    }
+}

--- a/course-service/src/main/java/com/comeon/courseservice/domain/course/entity/Course.java
+++ b/course-service/src/main/java/com/comeon/courseservice/domain/course/entity/Course.java
@@ -1,6 +1,7 @@
 package com.comeon.courseservice.domain.course.entity;
 
 import com.comeon.courseservice.domain.common.BaseTimeEntity;
+import com.comeon.courseservice.domain.courseplace.entity.CoursePlace;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,15 +32,27 @@ public class Course extends BaseTimeEntity {
     @OneToMany(mappedBy = "course", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
     private List<CoursePlace> coursePlaces = new ArrayList<>();
 
+    @Enumerated(value = EnumType.STRING)
+    private CourseWriteStatus writeStatus;
+
     @Builder
     public Course(Long userId, String title, String description, CourseImage courseImage) {
         this.userId = userId;
         this.title = title;
         this.description = description;
         this.courseImage = courseImage;
+        this.writeStatus = CourseWriteStatus.WRITING;
     }
 
     public void addCoursePlace(CoursePlace coursePlace) {
         coursePlaces.add(coursePlace);
+    }
+
+    public void completeWriting() {
+        this.writeStatus = CourseWriteStatus.COMPLETE;
+    }
+
+    public boolean canCompleteWriting() {
+        return !coursePlaces.isEmpty();
     }
 }

--- a/course-service/src/main/java/com/comeon/courseservice/domain/course/entity/Course.java
+++ b/course-service/src/main/java/com/comeon/courseservice/domain/course/entity/Course.java
@@ -49,10 +49,8 @@ public class Course extends BaseTimeEntity {
     }
 
     public void completeWriting() {
-        this.writeStatus = CourseWriteStatus.COMPLETE;
-    }
-
-    public boolean canCompleteWriting() {
-        return !coursePlaces.isEmpty();
+        if (this.writeStatus != CourseWriteStatus.COMPLETE) {
+            this.writeStatus = CourseWriteStatus.COMPLETE;
+        }
     }
 }

--- a/course-service/src/main/java/com/comeon/courseservice/domain/course/entity/Course.java
+++ b/course-service/src/main/java/com/comeon/courseservice/domain/course/entity/Course.java
@@ -1,0 +1,45 @@
+package com.comeon.courseservice.domain.course.entity;
+
+import com.comeon.courseservice.domain.common.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Course extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "course_id")
+    private Long id;
+
+    private Long userId;
+
+    private String title;
+
+    private String description;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+    @JoinColumn(name = "course_image")
+    private CourseImage courseImage;
+
+    @OneToMany(mappedBy = "course", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+    private List<CoursePlace> coursePlaces = new ArrayList<>();
+
+    @Builder
+    public Course(Long userId, String title, String description, CourseImage courseImage) {
+        this.userId = userId;
+        this.title = title;
+        this.description = description;
+        this.courseImage = courseImage;
+    }
+
+    public void addCoursePlace(CoursePlace coursePlace) {
+        coursePlaces.add(coursePlace);
+    }
+}

--- a/course-service/src/main/java/com/comeon/courseservice/domain/course/entity/CourseImage.java
+++ b/course-service/src/main/java/com/comeon/courseservice/domain/course/entity/CourseImage.java
@@ -1,5 +1,6 @@
 package com.comeon.courseservice.domain.course.entity;
 
+import com.comeon.courseservice.domain.common.BaseTimeEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,7 +10,7 @@ import javax.persistence.*;
 
 @Entity @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class CourseImage {
+public class CourseImage extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "course_img_id")

--- a/course-service/src/main/java/com/comeon/courseservice/domain/course/entity/CourseImage.java
+++ b/course-service/src/main/java/com/comeon/courseservice/domain/course/entity/CourseImage.java
@@ -1,0 +1,28 @@
+package com.comeon.courseservice.domain.course.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CourseImage {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "course_img_id")
+    private Long id;
+
+    private String originalName;
+
+    private String storedName;
+
+    @Builder
+    public CourseImage(String originalName, String storedName) {
+        this.originalName = originalName;
+        this.storedName = storedName;
+    }
+
+}

--- a/course-service/src/main/java/com/comeon/courseservice/domain/course/entity/CoursePlace.java
+++ b/course-service/src/main/java/com/comeon/courseservice/domain/course/entity/CoursePlace.java
@@ -1,0 +1,44 @@
+package com.comeon.courseservice.domain.course.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CoursePlace {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "course_place_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "course_id")
+    private Course course;
+
+    private String name;
+
+    private String description;
+
+    private Double lat;
+
+    private Double lng;
+
+    @Column(name = "orders")
+    private Integer order;
+
+    @Builder
+    public CoursePlace(Course course, String name, String description, Double lat, Double lng, Integer order) {
+        this.course = course;
+        this.name = name;
+        this.description = description;
+        this.lat = lat;
+        this.lng = lng;
+        this.order = order;
+
+        course.addCoursePlace(this);
+    }
+}

--- a/course-service/src/main/java/com/comeon/courseservice/domain/course/entity/CourseWriteStatus.java
+++ b/course-service/src/main/java/com/comeon/courseservice/domain/course/entity/CourseWriteStatus.java
@@ -1,0 +1,8 @@
+package com.comeon.courseservice.domain.course.entity;
+
+public enum CourseWriteStatus {
+
+    WRITING,
+    COMPLETE,
+    ;
+}

--- a/course-service/src/main/java/com/comeon/courseservice/domain/course/repository/CourseRepository.java
+++ b/course-service/src/main/java/com/comeon/courseservice/domain/course/repository/CourseRepository.java
@@ -1,0 +1,7 @@
+package com.comeon.courseservice.domain.course.repository;
+
+import com.comeon.courseservice.domain.course.entity.Course;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CourseRepository extends JpaRepository<Course, Long> {
+}

--- a/course-service/src/main/java/com/comeon/courseservice/domain/course/repository/CourseRepository.java
+++ b/course-service/src/main/java/com/comeon/courseservice/domain/course/repository/CourseRepository.java
@@ -1,7 +1,16 @@
 package com.comeon.courseservice.domain.course.repository;
 
 import com.comeon.courseservice.domain.course.entity.Course;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface CourseRepository extends JpaRepository<Course, Long> {
+
+    @EntityGraph(attributePaths = {"coursePlaces"})
+    @Query("select c from Course c where c.id = :courseId")
+    Optional<Course> findByIdFetchCoursePlaces(@Param("courseId") Long courseId);
 }

--- a/course-service/src/main/java/com/comeon/courseservice/domain/course/service/CourseService.java
+++ b/course-service/src/main/java/com/comeon/courseservice/domain/course/service/CourseService.java
@@ -1,0 +1,25 @@
+package com.comeon.courseservice.domain.course.service;
+
+import com.comeon.courseservice.domain.course.repository.CourseRepository;
+import com.comeon.courseservice.domain.course.service.dto.CourseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CourseService {
+
+    private final CourseRepository courseRepository;
+
+    // 코스 저장
+    public Long saveCourse(CourseDto courseDto) {
+        return courseRepository.save(courseDto.toEntity()).getId();
+    }
+
+    // 코스 수정
+
+    // 코스 삭제
+
+}

--- a/course-service/src/main/java/com/comeon/courseservice/domain/course/service/CourseService.java
+++ b/course-service/src/main/java/com/comeon/courseservice/domain/course/service/CourseService.java
@@ -25,24 +25,6 @@ public class CourseService {
         return courseRepository.save(courseDto.toEntity()).getId();
     }
 
-    // 코스 작성 상태 수정
-    public void completeWritingCourse(Long courseId, Long userId) {
-        Course course = courseRepository.findById(courseId)
-                .orElseThrow(
-                        () -> new EntityNotFoundException("해당 식별자를 가진 Course가 없습니다. 요청한 Course 식별값 : " + courseId)
-                );
-
-        if (!Objects.equals(course.getUserId(), userId)) {
-            throw new CustomException("수정할 권한이 없습니다. 요청한 유저 식별값 : " + userId, ErrorCode.NO_AUTHORITIES);
-        }
-
-        if (!course.canCompleteWriting()) {
-            throw new CustomException("코스 작성이 완료되지 않았습니다. 요청을 처리할 수 없습니다.", ErrorCode.VALIDATION_FAIL);
-        }
-
-        course.completeWriting();
-    }
-
     // 코스 수정
 
     // 코스 삭제

--- a/course-service/src/main/java/com/comeon/courseservice/domain/course/service/CourseService.java
+++ b/course-service/src/main/java/com/comeon/courseservice/domain/course/service/CourseService.java
@@ -1,10 +1,16 @@
 package com.comeon.courseservice.domain.course.service;
 
+import com.comeon.courseservice.common.exception.CustomException;
+import com.comeon.courseservice.common.exception.ErrorCode;
+import com.comeon.courseservice.domain.common.exception.EntityNotFoundException;
+import com.comeon.courseservice.domain.course.entity.Course;
 import com.comeon.courseservice.domain.course.repository.CourseRepository;
 import com.comeon.courseservice.domain.course.service.dto.CourseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
 
 @Service
 @Transactional
@@ -15,7 +21,26 @@ public class CourseService {
 
     // 코스 저장
     public Long saveCourse(CourseDto courseDto) {
+        // TODO 유저 정보 확인 필요?
         return courseRepository.save(courseDto.toEntity()).getId();
+    }
+
+    // 코스 작성 상태 수정
+    public void completeWritingCourse(Long courseId, Long userId) {
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(
+                        () -> new EntityNotFoundException("해당 식별자를 가진 Course가 없습니다. 요청한 Course 식별값 : " + courseId)
+                );
+
+        if (!Objects.equals(course.getUserId(), userId)) {
+            throw new CustomException("수정할 권한이 없습니다. 요청한 유저 식별값 : " + userId, ErrorCode.NO_AUTHORITIES);
+        }
+
+        if (!course.canCompleteWriting()) {
+            throw new CustomException("코스 작성이 완료되지 않았습니다. 요청을 처리할 수 없습니다.", ErrorCode.VALIDATION_FAIL);
+        }
+
+        course.completeWriting();
     }
 
     // 코스 수정

--- a/course-service/src/main/java/com/comeon/courseservice/domain/course/service/dto/CourseDto.java
+++ b/course-service/src/main/java/com/comeon/courseservice/domain/course/service/dto/CourseDto.java
@@ -1,0 +1,50 @@
+package com.comeon.courseservice.domain.course.service.dto;
+
+import com.comeon.courseservice.domain.course.entity.Course;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class CourseDto {
+
+    private Long userId;
+    private String title;
+    private String description;
+    private CourseImageDto courseImageDto;
+
+    private List<CoursePlaceDto> coursePlaceDtos;
+
+    @Builder
+    public CourseDto(Long userId, String title, String description, CourseImageDto courseImageDto, List<CoursePlaceDto> coursePlaceDtos) {
+        this.userId = userId;
+        this.title = title;
+        this.description = description;
+        this.courseImageDto = courseImageDto;
+        this.coursePlaceDtos = coursePlaceDtos;
+    }
+
+    public Course toEntity() {
+        Course course = Course.builder()
+                .userId(userId)
+                .title(title)
+                .description(description)
+                .courseImage(courseImageDto.toEntity())
+                .build();
+
+        coursePlaceDtos.forEach(
+                coursePlaceDto -> coursePlaceDto.toEntity(course)
+        );
+
+        return course;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public void setCourseImageDto(CourseImageDto courseImageDto) {
+        this.courseImageDto = courseImageDto;
+    }
+}

--- a/course-service/src/main/java/com/comeon/courseservice/domain/course/service/dto/CourseDto.java
+++ b/course-service/src/main/java/com/comeon/courseservice/domain/course/service/dto/CourseDto.java
@@ -4,8 +4,6 @@ import com.comeon.courseservice.domain.course.entity.Course;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.util.List;
-
 @Getter
 public class CourseDto {
 
@@ -14,30 +12,21 @@ public class CourseDto {
     private String description;
     private CourseImageDto courseImageDto;
 
-    private List<CoursePlaceDto> coursePlaceDtos;
-
     @Builder
-    public CourseDto(Long userId, String title, String description, CourseImageDto courseImageDto, List<CoursePlaceDto> coursePlaceDtos) {
+    public CourseDto(Long userId, String title, String description, CourseImageDto courseImageDto) {
         this.userId = userId;
         this.title = title;
         this.description = description;
         this.courseImageDto = courseImageDto;
-        this.coursePlaceDtos = coursePlaceDtos;
     }
 
     public Course toEntity() {
-        Course course = Course.builder()
+        return Course.builder()
                 .userId(userId)
                 .title(title)
                 .description(description)
                 .courseImage(courseImageDto.toEntity())
                 .build();
-
-        coursePlaceDtos.forEach(
-                coursePlaceDto -> coursePlaceDto.toEntity(course)
-        );
-
-        return course;
     }
 
     public void setUserId(Long userId) {

--- a/course-service/src/main/java/com/comeon/courseservice/domain/course/service/dto/CourseImageDto.java
+++ b/course-service/src/main/java/com/comeon/courseservice/domain/course/service/dto/CourseImageDto.java
@@ -1,0 +1,25 @@
+package com.comeon.courseservice.domain.course.service.dto;
+
+import com.comeon.courseservice.domain.course.entity.CourseImage;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CourseImageDto {
+
+    private String originalName;
+    private String storedName;
+
+    @Builder
+    public CourseImageDto(String originalName, String storedName) {
+        this.originalName = originalName;
+        this.storedName = storedName;
+    }
+
+    public CourseImage toEntity() {
+        return CourseImage.builder()
+                .originalName(originalName)
+                .storedName(storedName)
+                .build();
+    }
+}

--- a/course-service/src/main/java/com/comeon/courseservice/domain/course/service/dto/CoursePlaceDto.java
+++ b/course-service/src/main/java/com/comeon/courseservice/domain/course/service/dto/CoursePlaceDto.java
@@ -1,0 +1,36 @@
+package com.comeon.courseservice.domain.course.service.dto;
+
+import com.comeon.courseservice.domain.course.entity.Course;
+import com.comeon.courseservice.domain.course.entity.CoursePlace;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CoursePlaceDto {
+
+    private String name;
+    private String description;
+    private Double lat;
+    private Double lng;
+    private Integer order;
+
+    @Builder
+    public CoursePlaceDto(String name, String description, Double lat, Double lng, Integer order) {
+        this.name = name;
+        this.description = description;
+        this.lat = lat;
+        this.lng = lng;
+        this.order = order;
+    }
+
+    public CoursePlace toEntity(Course course) {
+        return CoursePlace.builder()
+                .course(course)
+                .name(name)
+                .description(description)
+                .lat(lat)
+                .lng(lng)
+                .order(order)
+                .build();
+    }
+}

--- a/course-service/src/main/java/com/comeon/courseservice/domain/courseplace/entity/CoursePlace.java
+++ b/course-service/src/main/java/com/comeon/courseservice/domain/courseplace/entity/CoursePlace.java
@@ -1,5 +1,7 @@
-package com.comeon.courseservice.domain.course.entity;
+package com.comeon.courseservice.domain.courseplace.entity;
 
+import com.comeon.courseservice.domain.common.BaseTimeEntity;
+import com.comeon.courseservice.domain.course.entity.Course;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,7 +11,7 @@ import javax.persistence.*;
 
 @Entity @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class CoursePlace {
+public class CoursePlace extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "course_place_id")

--- a/course-service/src/main/java/com/comeon/courseservice/domain/courseplace/repository/CoursePlaceRepository.java
+++ b/course-service/src/main/java/com/comeon/courseservice/domain/courseplace/repository/CoursePlaceRepository.java
@@ -1,0 +1,7 @@
+package com.comeon.courseservice.domain.courseplace.repository;
+
+import com.comeon.courseservice.domain.courseplace.entity.CoursePlace;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CoursePlaceRepository extends JpaRepository<CoursePlace, Long> {
+}

--- a/course-service/src/main/java/com/comeon/courseservice/domain/courseplace/service/CoursePlaceService.java
+++ b/course-service/src/main/java/com/comeon/courseservice/domain/courseplace/service/CoursePlaceService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Objects;
 
 @Service
@@ -22,23 +23,50 @@ public class CoursePlaceService {
     private final CourseRepository courseRepository;
     private final CoursePlaceRepository coursePlaceRepository;
 
+    // return savedCoursePlace.id
     public Long saveCoursePlace(Long courseId, Long userId, CoursePlaceDto coursePlaceDto) {
-        Course course = courseRepository.findByIdFetchCoursePlaces(courseId)
-                .orElseThrow(
-                        () -> new EntityNotFoundException("해당 식별자를 가진 Course가 없습니다. 요청한 Course 식별값 : " + courseId)
-                );
+        Course course = getCourse(courseId);
 
-        if (!Objects.equals(course.getUserId(), userId)) {
-            throw new CustomException("해당 코스에 장소를 등록 할 권한이 없습니다. 요청한 유저 식별값 : " + userId, ErrorCode.NO_AUTHORITIES);
-        }
+        checkWriter(userId, course);
 
         Integer order = course.getCoursePlaces().stream()
                 .mapToInt(CoursePlace::getOrder)
                 .max()
                 .orElse(0) + 1;
+        coursePlaceDto.setOrder(order);
 
-        CoursePlace coursePlace = coursePlaceDto.toEntity(course, order);
+        CoursePlace coursePlace = coursePlaceDto.toEntity(course);
 
         return coursePlaceRepository.save(coursePlace).getId();
+    }
+
+    public void batchSaveCoursePlace(Long courseId, Long userId, List<CoursePlaceDto> coursePlaceDtoList) {
+        Course course = getCourse(courseId);
+
+        checkWriter(userId, course);
+
+        coursePlaceDtoList.forEach(coursePlaceDto -> coursePlaceDto.toEntity(course));
+
+        if (course.getCoursePlaces().isEmpty()) {
+            throw new CustomException("코스 작성이 완료되지 않았습니다. 요청을 처리할 수 없습니다.", ErrorCode.VALIDATION_FAIL);
+        }
+
+        course.completeWriting();
+        // TODO 리턴값?
+    }
+
+
+    /* === private method === */
+    private Course getCourse(Long courseId) {
+        return courseRepository.findByIdFetchCoursePlaces(courseId)
+                .orElseThrow(
+                        () -> new EntityNotFoundException("해당 식별자를 가진 Course가 없습니다. 요청한 Course 식별값 : " + courseId)
+                );
+    }
+
+    private void checkWriter(Long userId, Course course) {
+        if (!Objects.equals(course.getUserId(), userId)) {
+            throw new CustomException("해당 코스에 장소를 등록 할 권한이 없습니다. 요청한 유저 식별값 : " + userId, ErrorCode.NO_AUTHORITIES);
+        }
     }
 }

--- a/course-service/src/main/java/com/comeon/courseservice/domain/courseplace/service/CoursePlaceService.java
+++ b/course-service/src/main/java/com/comeon/courseservice/domain/courseplace/service/CoursePlaceService.java
@@ -1,0 +1,36 @@
+package com.comeon.courseservice.domain.courseplace.service;
+
+import com.comeon.courseservice.domain.common.exception.EntityNotFoundException;
+import com.comeon.courseservice.domain.course.entity.Course;
+import com.comeon.courseservice.domain.course.repository.CourseRepository;
+import com.comeon.courseservice.domain.courseplace.entity.CoursePlace;
+import com.comeon.courseservice.domain.courseplace.repository.CoursePlaceRepository;
+import com.comeon.courseservice.domain.courseplace.service.dto.CoursePlaceDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CoursePlaceService {
+
+    private final CourseRepository courseRepository;
+    private final CoursePlaceRepository coursePlaceRepository;
+
+    public Long saveCoursePlace(Long courseId, CoursePlaceDto coursePlaceDto) {
+        Course course = courseRepository.findByIdFetchCoursePlaces(courseId)
+                .orElseThrow(
+                        () -> new EntityNotFoundException("해당 식별자를 가진 Course가 없습니다. 요청한 Course 식별값 : " + courseId)
+                );
+
+        Integer order = course.getCoursePlaces().stream()
+                .mapToInt(CoursePlace::getOrder)
+                .max()
+                .orElse(0) + 1;
+
+        CoursePlace coursePlace = coursePlaceDto.toEntity(course, order);
+
+        return coursePlaceRepository.save(coursePlace).getId();
+    }
+}

--- a/course-service/src/main/java/com/comeon/courseservice/domain/courseplace/service/CoursePlaceService.java
+++ b/course-service/src/main/java/com/comeon/courseservice/domain/courseplace/service/CoursePlaceService.java
@@ -1,5 +1,7 @@
 package com.comeon.courseservice.domain.courseplace.service;
 
+import com.comeon.courseservice.common.exception.CustomException;
+import com.comeon.courseservice.common.exception.ErrorCode;
 import com.comeon.courseservice.domain.common.exception.EntityNotFoundException;
 import com.comeon.courseservice.domain.course.entity.Course;
 import com.comeon.courseservice.domain.course.repository.CourseRepository;
@@ -10,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Objects;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -18,11 +22,15 @@ public class CoursePlaceService {
     private final CourseRepository courseRepository;
     private final CoursePlaceRepository coursePlaceRepository;
 
-    public Long saveCoursePlace(Long courseId, CoursePlaceDto coursePlaceDto) {
+    public Long saveCoursePlace(Long courseId, Long userId, CoursePlaceDto coursePlaceDto) {
         Course course = courseRepository.findByIdFetchCoursePlaces(courseId)
                 .orElseThrow(
                         () -> new EntityNotFoundException("해당 식별자를 가진 Course가 없습니다. 요청한 Course 식별값 : " + courseId)
                 );
+
+        if (!Objects.equals(course.getUserId(), userId)) {
+            throw new CustomException("해당 코스에 장소를 등록 할 권한이 없습니다. 요청한 유저 식별값 : " + userId, ErrorCode.NO_AUTHORITIES);
+        }
 
         Integer order = course.getCoursePlaces().stream()
                 .mapToInt(CoursePlace::getOrder)

--- a/course-service/src/main/java/com/comeon/courseservice/domain/courseplace/service/dto/CoursePlaceDto.java
+++ b/course-service/src/main/java/com/comeon/courseservice/domain/courseplace/service/dto/CoursePlaceDto.java
@@ -12,16 +12,22 @@ public class CoursePlaceDto {
     private String description;
     private Double lat;
     private Double lng;
+    private Integer order;
 
     @Builder
-    public CoursePlaceDto(String name, String description, Double lat, Double lng) {
+    public CoursePlaceDto(String name, String description, Double lat, Double lng, Integer order) {
         this.name = name;
         this.description = description;
         this.lat = lat;
         this.lng = lng;
+        this.order = order;
     }
 
-    public CoursePlace toEntity(Course course, Integer order) {
+    public void setOrder(Integer order) {
+        this.order = order;
+    }
+
+    public CoursePlace toEntity(Course course) {
         return CoursePlace.builder()
                 .course(course)
                 .name(name)

--- a/course-service/src/main/java/com/comeon/courseservice/domain/courseplace/service/dto/CoursePlaceDto.java
+++ b/course-service/src/main/java/com/comeon/courseservice/domain/courseplace/service/dto/CoursePlaceDto.java
@@ -1,7 +1,7 @@
-package com.comeon.courseservice.domain.course.service.dto;
+package com.comeon.courseservice.domain.courseplace.service.dto;
 
 import com.comeon.courseservice.domain.course.entity.Course;
-import com.comeon.courseservice.domain.course.entity.CoursePlace;
+import com.comeon.courseservice.domain.courseplace.entity.CoursePlace;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,18 +12,16 @@ public class CoursePlaceDto {
     private String description;
     private Double lat;
     private Double lng;
-    private Integer order;
 
     @Builder
-    public CoursePlaceDto(String name, String description, Double lat, Double lng, Integer order) {
+    public CoursePlaceDto(String name, String description, Double lat, Double lng) {
         this.name = name;
         this.description = description;
         this.lat = lat;
         this.lng = lng;
-        this.order = order;
     }
 
-    public CoursePlace toEntity(Course course) {
+    public CoursePlace toEntity(Course course, Integer order) {
         return CoursePlace.builder()
                 .course(course)
                 .name(name)

--- a/course-service/src/main/java/com/comeon/courseservice/web/common/aop/ValidationAspect.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/common/aop/ValidationAspect.java
@@ -1,0 +1,79 @@
+package com.comeon.courseservice.web.common.aop;
+
+import com.comeon.courseservice.common.exception.CustomException;
+import com.comeon.courseservice.common.exception.ErrorCode;
+import com.comeon.courseservice.web.common.exception.ValidateException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.context.MessageSource;
+import org.springframework.context.MessageSourceResolvable;
+import org.springframework.context.NoSuchMessageException;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.ObjectError;
+
+import java.util.Arrays;
+import java.util.Locale;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class ValidationAspect {
+
+    private final MessageSource messageSource;
+
+    @Pointcut("execution(* com.comeon.courseservice.web..*.*(..))")
+    public void webPackagePointcut() {
+    }
+
+    @Before("webPackagePointcut() && @annotation(annotation)")
+    public void validate(JoinPoint joinPoint, ValidationRequired annotation) {
+        BindingResult bindingResult = Arrays.stream(joinPoint.getArgs())
+                .filter(BindingResult.class::isInstance)
+                .map(BindingResult.class::cast)
+                .findFirst()
+                .orElseThrow(
+                        () -> new CustomException(
+                                "BindingResult가 없습니다. Target Class : " + joinPoint.getTarget().getClass().getSimpleName(),
+                                ErrorCode.SERVER_ERROR
+                        )
+                );
+
+        if (bindingResult.hasErrors()) {
+            LinkedMultiValueMap<String, String> errorResult = new LinkedMultiValueMap<>();
+
+            bindingResult.getFieldErrors()
+                    .forEach(fieldError -> errorResult.add(
+                                    fieldError.getField(),
+                                    getMessage(fieldError)
+                            )
+                    );
+
+            bindingResult.getGlobalErrors()
+                    .forEach(objectError -> errorResult.add(
+                                    "Global",
+                                    getMessage(objectError)
+                            )
+                    );
+
+            throw new ValidateException("요청 데이터 검증에 실패하였습니다.\n" + errorResult, errorResult);
+        }
+    }
+
+    private String getMessage(MessageSourceResolvable resolvable) {
+        try {
+            return messageSource.getMessage(resolvable, Locale.getDefault());
+        } catch (NoSuchMessageException e) {
+            ObjectError error = (ObjectError) resolvable;
+            log.warn("[{}] 코드와 매칭되는 메시지가 없습니다. Code : {}", e.getClass().getSimpleName(), error.getCode(), e);
+            return null;
+        }
+    }
+}
+

--- a/course-service/src/main/java/com/comeon/courseservice/web/common/aop/ValidationRequired.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/common/aop/ValidationRequired.java
@@ -1,0 +1,12 @@
+package com.comeon.courseservice.web.common.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidationRequired {
+}
+

--- a/course-service/src/main/java/com/comeon/courseservice/web/common/exception/ValidateException.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/common/exception/ValidateException.java
@@ -1,0 +1,22 @@
+package com.comeon.courseservice.web.common.exception;
+
+import com.comeon.courseservice.common.exception.CustomException;
+import com.comeon.courseservice.common.exception.ErrorCode;
+import org.springframework.util.MultiValueMap;
+
+public class ValidateException extends CustomException {
+
+    private static final ErrorCode VALIDATION_FAIL = ErrorCode.VALIDATION_FAIL;
+
+    private final MultiValueMap<String, String> errorResult;
+
+    public ValidateException(String message, MultiValueMap<String, String> errorResult) {
+        super(message, VALIDATION_FAIL);
+        this.errorResult = errorResult;
+    }
+
+    public MultiValueMap<String, String> getErrorResult() {
+        return errorResult;
+    }
+}
+

--- a/course-service/src/main/java/com/comeon/courseservice/web/common/exception/resolver/CommonControllerAdvice.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/common/exception/resolver/CommonControllerAdvice.java
@@ -1,0 +1,34 @@
+package com.comeon.courseservice.web.common.exception.resolver;
+
+import com.comeon.courseservice.common.exception.CustomException;
+import com.comeon.courseservice.common.exception.ErrorCode;
+import com.comeon.courseservice.web.common.exception.ValidateException;
+import com.comeon.courseservice.web.common.response.ApiResponse;
+import com.comeon.courseservice.web.common.response.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice(basePackages = "com.comeon.courseservice.web")
+public class CommonControllerAdvice {
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<ErrorResponse>> validateExceptionHandle(ValidateException e) {
+        log.error("[{}]", e.getClass(), e);
+
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(ApiResponse.createBadParameter(errorCode, e.getErrorResult()));
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<ErrorResponse>> customExceptionHandle(CustomException e) {
+        log.error("[{}]", e.getClass(), e);
+
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(ApiResponse.createServerError(errorCode));
+    }
+}

--- a/course-service/src/main/java/com/comeon/courseservice/web/common/file/FileManager.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/common/file/FileManager.java
@@ -1,0 +1,12 @@
+package com.comeon.courseservice.web.common.file;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface FileManager {
+
+    UploadedFileInfo upload(MultipartFile multipartFile, String dirName);
+
+    void delete(String storedFileName, String dirName);
+
+    String getFileUrl(String storedFileName, String dirName);
+}

--- a/course-service/src/main/java/com/comeon/courseservice/web/common/file/S3FileManager.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/common/file/S3FileManager.java
@@ -1,0 +1,80 @@
+package com.comeon.courseservice.web.common.file;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.comeon.courseservice.common.exception.CustomException;
+import com.comeon.courseservice.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class S3FileManager implements FileManager {
+
+    private final AmazonS3 amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Override
+    public UploadedFileInfo upload(MultipartFile multipartFile, String dirName) {
+
+        if (Objects.isNull(multipartFile) || multipartFile.isEmpty()) {
+            throw new CustomException("파일이 비어있습니다.", ErrorCode.EMPTY_FILE);
+        }
+
+        String originalFileName = multipartFile.getOriginalFilename();
+        String storedFileName = createStoredFileName(originalFileName);
+
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType(multipartFile.getContentType());
+
+        try (InputStream inputStream = multipartFile.getInputStream()) {
+            amazonS3Client.putObject(
+                    new PutObjectRequest(bucket, generateStoredPath(storedFileName, dirName), inputStream, objectMetadata)
+                            .withCannedAcl(CannedAccessControlList.PublicRead)
+            );
+        } catch (IOException e) {
+            throw new CustomException("파일 업로드 중 예외 발생", e, ErrorCode.UPLOAD_FAIL);
+        }
+
+        return new UploadedFileInfo(originalFileName, storedFileName);
+    }
+
+    @Override
+    public void delete(String storedFileName, String dirName) {
+        amazonS3Client.deleteObject(
+                new DeleteObjectRequest(
+                        bucket,
+                        generateStoredPath(storedFileName, dirName)
+                )
+        );
+    }
+
+    @Override
+    public String getFileUrl(String storedFileName, String dirName) {
+        return amazonS3Client.getUrl(bucket, generateStoredPath(storedFileName, dirName)).toString();
+    }
+
+    private String generateStoredPath(String storedFileName, String dirName) {
+        return dirName + "/" + storedFileName;
+    }
+
+    private String createStoredFileName(String originalFileName) {
+        int pos = originalFileName.lastIndexOf(".");
+        String ext = originalFileName.substring(pos + 1);
+
+        return UUID.randomUUID() + "." + ext;
+    }
+}
+

--- a/course-service/src/main/java/com/comeon/courseservice/web/common/file/UploadedFileInfo.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/common/file/UploadedFileInfo.java
@@ -1,0 +1,13 @@
+package com.comeon.courseservice.web.common.file;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UploadedFileInfo {
+
+    private String originalFileName;
+    private String storedFileName;
+
+}

--- a/course-service/src/main/java/com/comeon/courseservice/web/common/response/ApiResponse.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/common/response/ApiResponse.java
@@ -1,0 +1,102 @@
+package com.comeon.courseservice.web.common.response;
+
+import com.comeon.courseservice.common.exception.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.util.MultiValueMap;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+
+    private LocalDateTime responseTime;
+
+    private ApiResponseCode code;
+
+    private T data;
+
+    public static <T> ApiResponse<T> createSuccess() {
+        return ApiResponse.<T>builder()
+                .responseTime(LocalDateTime.now())
+                .code(ApiResponseCode.SUCCESS)
+                .build();
+    }
+
+    public static <T> ApiResponse<T> createSuccess(T data) {
+        return ApiResponse.<T>builder()
+                .responseTime(LocalDateTime.now())
+                .code(ApiResponseCode.SUCCESS)
+                .data(data)
+                .build();
+    }
+
+    public static ApiResponse<ErrorResponse> createBadParameter(ErrorCode errorCode) {
+        ErrorResponse errorResponse = createErrorResponse(errorCode);
+
+        return ApiResponse.<ErrorResponse>builder()
+                .responseTime(LocalDateTime.now())
+                .code(ApiResponseCode.BAD_PARAMETER)
+                .data(errorResponse)
+                .build();
+    }
+
+    public static ApiResponse<ErrorResponse> createBadParameter(ErrorCode errorCode, MultiValueMap<String, String> errorResult) {
+        ErrorResponse errorResponse = createValidateErrorResponse(errorCode, errorResult);
+
+        return ApiResponse.<ErrorResponse>builder()
+                .responseTime(LocalDateTime.now())
+                .code(ApiResponseCode.BAD_PARAMETER)
+                .data(errorResponse)
+                .build();
+    }
+
+    public static ApiResponse<ErrorResponse> createNotFound(ErrorCode errorCode) {
+        ErrorResponse errorResponse = createErrorResponse(errorCode);
+
+        return ApiResponse.<ErrorResponse>builder()
+                .responseTime(LocalDateTime.now())
+                .code(ApiResponseCode.NOT_FOUND)
+                .data(errorResponse)
+                .build();
+    }
+
+    public static ApiResponse<ErrorResponse> createServerError(ErrorCode errorCode) {
+        ErrorResponse errorResponse = createErrorResponse(errorCode);
+
+        return ApiResponse.<ErrorResponse>builder()
+                .responseTime(LocalDateTime.now())
+                .code(ApiResponseCode.SERVER_ERROR)
+                .data(errorResponse)
+                .build();
+    }
+
+    public static ApiResponse<ErrorResponse> createUnauthorized(ErrorCode errorCode) {
+        ErrorResponse errorResponse = createErrorResponse(errorCode);
+
+        return ApiResponse.<ErrorResponse>builder()
+                .responseTime(LocalDateTime.now())
+                .code(ApiResponseCode.UNAUTHORIZED)
+                .data(errorResponse)
+                .build();
+    }
+
+    private static ErrorResponse createErrorResponse(ErrorCode errorCode) {
+        return ErrorResponse.builder()
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .build();
+    }
+
+    private static ErrorResponse createValidateErrorResponse(ErrorCode errorCode, MultiValueMap<String, String> errorResult) {
+        return ErrorResponse.builder()
+                .code(errorCode.getCode())
+                .message(errorResult)
+                .build();
+    }
+}

--- a/course-service/src/main/java/com/comeon/courseservice/web/common/response/ApiResponseCode.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/common/response/ApiResponseCode.java
@@ -1,0 +1,24 @@
+package com.comeon.courseservice.web.common.response;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum ApiResponseCode {
+
+    SUCCESS("요청이 성공하였습니다."),
+    BAD_PARAMETER("요청 파라미터가 잘못되었습니다."),
+    NOT_FOUND("리소스를 찾지 못했습니다."),
+    UNAUTHORIZED("인증에 실패하였습니다."),
+    SERVER_ERROR("서버 에러입니다."),
+    ;
+
+    private final String message;
+
+    public String getId() {
+        return name();
+    }
+
+    public String getText() {
+        return message;
+    }
+}

--- a/course-service/src/main/java/com/comeon/courseservice/web/common/response/ErrorResponse.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/common/response/ErrorResponse.java
@@ -1,0 +1,14 @@
+package com.comeon.courseservice.web.common.response;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ErrorResponse<T> {
+
+    private Integer code;
+    private T message;
+
+}

--- a/course-service/src/main/java/com/comeon/courseservice/web/course/controller/CourseController.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/course/controller/CourseController.java
@@ -10,7 +10,6 @@ import com.comeon.courseservice.web.common.file.UploadedFileInfo;
 import com.comeon.courseservice.web.common.response.ApiResponse;
 import com.comeon.courseservice.web.course.request.CourseSaveRequest;
 import com.comeon.courseservice.web.course.response.CourseSaveResponse;
-import com.comeon.courseservice.web.course.response.CourseWritingDoneResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,7 +23,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/courses")
 public class CourseController {
 
-    @Value("${profile.dirName}")
+    @Value("${s3.folder-name.course}")
     private String dirName;
 
     private final FileManager fileManager;
@@ -55,15 +54,6 @@ public class CourseController {
         }
 
         return ApiResponse.createSuccess(new CourseSaveResponse(courseId));
-    }
-
-    // 코스 작성 완료 처리 PATCH /courses/{courseId}/done
-    @PatchMapping("/{courseId}/done")
-    public ApiResponse<CourseWritingDoneResponse> courseWritingDone(@CurrentUserId Long currentUserId,
-                                            @PathVariable Long courseId) {
-        courseService.completeWritingCourse(courseId, currentUserId);
-
-        return ApiResponse.createSuccess(new CourseWritingDoneResponse());
     }
 
     // 코스 단건 조회 GET /courses/{courseId}

--- a/course-service/src/main/java/com/comeon/courseservice/web/course/controller/CourseController.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/course/controller/CourseController.java
@@ -10,6 +10,7 @@ import com.comeon.courseservice.web.common.file.UploadedFileInfo;
 import com.comeon.courseservice.web.common.response.ApiResponse;
 import com.comeon.courseservice.web.course.request.CourseSaveRequest;
 import com.comeon.courseservice.web.course.response.CourseSaveResponse;
+import com.comeon.courseservice.web.course.response.CourseWritingDoneResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -54,6 +55,15 @@ public class CourseController {
         }
 
         return ApiResponse.createSuccess(new CourseSaveResponse(courseId));
+    }
+
+    // 코스 작성 완료 처리 PATCH /courses/{courseId}/done
+    @PatchMapping("/{courseId}/done")
+    public ApiResponse<?> courseWritingDone(@CurrentUserId Long currentUserId,
+                                            @PathVariable Long courseId) {
+        courseService.completeWritingCourse(courseId, currentUserId);
+
+        return ApiResponse.createSuccess(new CourseWritingDoneResponse());
     }
 
     // 코스 단건 조회 GET /courses/{courseId}

--- a/course-service/src/main/java/com/comeon/courseservice/web/course/controller/CourseController.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/course/controller/CourseController.java
@@ -1,0 +1,79 @@
+package com.comeon.courseservice.web.course.controller;
+
+import com.comeon.courseservice.config.argresolver.CurrentUserId;
+import com.comeon.courseservice.domain.course.service.CourseService;
+import com.comeon.courseservice.domain.course.service.dto.CourseDto;
+import com.comeon.courseservice.domain.course.service.dto.CourseImageDto;
+import com.comeon.courseservice.web.common.aop.ValidationRequired;
+import com.comeon.courseservice.web.common.file.FileManager;
+import com.comeon.courseservice.web.common.file.UploadedFileInfo;
+import com.comeon.courseservice.web.common.response.ApiResponse;
+import com.comeon.courseservice.web.course.request.CourseSaveRequest;
+import com.comeon.courseservice.web.course.response.CourseSaveResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/courses")
+public class CourseController {
+
+    @Value("${profile.dirName}")
+    private String dirName;
+
+    private final FileManager fileManager;
+    private final CourseService courseService;
+
+    // 코스 저장 POST /courses
+    @ValidationRequired
+    @PostMapping
+    public ApiResponse<CourseSaveResponse> courseSave(@CurrentUserId Long currentUserId,
+                                                      @Validated @ModelAttribute CourseSaveRequest request,
+                                                      BindingResult bindingResult) {
+        // 이미지 저장 후, 코스 이미지 dto로 변환
+        CourseImageDto courseImageDto = generateCourseImageDto(
+                fileManager.upload(request.getImgFile(), dirName)
+        );
+
+        // 요청 데이터 -> 코스 dto로 변환
+        CourseDto courseDto = request.toServiceDto();
+        courseDto.setUserId(currentUserId);
+        courseDto.setCourseImageDto(courseImageDto);
+
+        Long courseId = null;
+        try {
+            courseId = courseService.saveCourse(courseDto);
+        } catch (RuntimeException e) {
+            fileManager.delete(courseImageDto.getStoredName(), dirName);
+            throw e;
+        }
+
+        return ApiResponse.createSuccess(new CourseSaveResponse(courseId));
+    }
+
+    // 코스 단건 조회 GET /courses/{courseId}
+
+    // 코스 목록 조회 GET /courses
+
+    // 코스 수정 PATCH /courses/{courseId}
+
+    // 코스 삭제 DELETE /courses/{courseId}
+
+    // 코스 장소 리스트 조회 GET /courses/{courseId}/course-places
+
+    // 코스 좋아요
+
+
+    /* ### private method ### */
+    private CourseImageDto generateCourseImageDto(UploadedFileInfo uploadedFileInfo) {
+        return CourseImageDto.builder()
+                .originalName(uploadedFileInfo.getOriginalFileName())
+                .storedName(uploadedFileInfo.getStoredFileName())
+                .build();
+    }
+}

--- a/course-service/src/main/java/com/comeon/courseservice/web/course/controller/CourseController.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/course/controller/CourseController.java
@@ -59,7 +59,7 @@ public class CourseController {
 
     // 코스 작성 완료 처리 PATCH /courses/{courseId}/done
     @PatchMapping("/{courseId}/done")
-    public ApiResponse<?> courseWritingDone(@CurrentUserId Long currentUserId,
+    public ApiResponse<CourseWritingDoneResponse> courseWritingDone(@CurrentUserId Long currentUserId,
                                             @PathVariable Long courseId) {
         courseService.completeWritingCourse(courseId, currentUserId);
 

--- a/course-service/src/main/java/com/comeon/courseservice/web/course/request/CourseSaveRequest.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/course/request/CourseSaveRequest.java
@@ -1,0 +1,70 @@
+package com.comeon.courseservice.web.course.request;
+
+import com.comeon.courseservice.domain.course.service.dto.CourseDto;
+import com.comeon.courseservice.domain.course.service.dto.CoursePlaceDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+public class CourseSaveRequest {
+
+    @NotNull
+    private MultipartFile imgFile;
+
+    @NotBlank
+    private String title;
+
+    @NotBlank
+    private String description;
+
+    @NotNull
+    List<CoursePlaceSaveRequest> coursePlaces;
+
+    public CourseDto toServiceDto() {
+        return CourseDto.builder()
+                .title(title)
+                .description(description)
+                .coursePlaceDtos(
+                        coursePlaces.stream()
+                                .map(CoursePlaceSaveRequest::toServiceDto)
+                                .collect(Collectors.toList())
+                )
+                .build();
+    }
+
+
+    public static class CoursePlaceSaveRequest {
+        private String name;
+        private String description;
+        private Double lat;
+        private Double lng;
+        private Integer order;
+
+        @Builder
+        public CoursePlaceSaveRequest(String name, String description, Double lat, Double lng, Integer order) {
+            this.name = name;
+            this.description = description;
+            this.lat = lat;
+            this.lng = lng;
+            this.order = order;
+        }
+
+        public CoursePlaceDto toServiceDto() {
+            return CoursePlaceDto.builder()
+                    .name(name)
+                    .description(description)
+                    .lat(lat)
+                    .lng(lng)
+                    .order(order)
+                    .build();
+        }
+    }
+}

--- a/course-service/src/main/java/com/comeon/courseservice/web/course/request/CourseSaveRequest.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/course/request/CourseSaveRequest.java
@@ -1,18 +1,14 @@
 package com.comeon.courseservice.web.course.request;
 
 import com.comeon.courseservice.domain.course.service.dto.CourseDto;
-import com.comeon.courseservice.domain.course.service.dto.CoursePlaceDto;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import java.util.List;
-import java.util.stream.Collectors;
 
-@Getter
+@Getter @Setter
+@NoArgsConstructor
 @AllArgsConstructor
 public class CourseSaveRequest {
 
@@ -25,46 +21,10 @@ public class CourseSaveRequest {
     @NotBlank
     private String description;
 
-    @NotNull
-    List<CoursePlaceSaveRequest> coursePlaces;
-
     public CourseDto toServiceDto() {
         return CourseDto.builder()
                 .title(title)
                 .description(description)
-                .coursePlaceDtos(
-                        coursePlaces.stream()
-                                .map(CoursePlaceSaveRequest::toServiceDto)
-                                .collect(Collectors.toList())
-                )
                 .build();
-    }
-
-
-    public static class CoursePlaceSaveRequest {
-        private String name;
-        private String description;
-        private Double lat;
-        private Double lng;
-        private Integer order;
-
-        @Builder
-        public CoursePlaceSaveRequest(String name, String description, Double lat, Double lng, Integer order) {
-            this.name = name;
-            this.description = description;
-            this.lat = lat;
-            this.lng = lng;
-            this.order = order;
-        }
-
-        public CoursePlaceDto toServiceDto() {
-            return CoursePlaceDto.builder()
-                    .name(name)
-                    .description(description)
-                    .lat(lat)
-                    .lng(lng)
-                    .order(order)
-                    .build();
-        }
     }
 }

--- a/course-service/src/main/java/com/comeon/courseservice/web/course/response/CourseSaveResponse.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/course/response/CourseSaveResponse.java
@@ -1,0 +1,11 @@
+package com.comeon.courseservice.web.course.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CourseSaveResponse {
+
+    private Long courseId;
+}

--- a/course-service/src/main/java/com/comeon/courseservice/web/course/response/CourseWritingDoneResponse.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/course/response/CourseWritingDoneResponse.java
@@ -1,0 +1,19 @@
+package com.comeon.courseservice.web.course.response;
+
+import lombok.Getter;
+
+@Getter
+public class CourseWritingDoneResponse {
+
+    public static final String SUCCESS_MESSAGE = "코스 등록 처리가 완료되었습니다.";
+
+    private String message;
+
+    public CourseWritingDoneResponse() {
+        this.message = SUCCESS_MESSAGE;
+    }
+
+    public CourseWritingDoneResponse(String message) {
+        this.message = message;
+    }
+}

--- a/course-service/src/main/java/com/comeon/courseservice/web/courseplace/controller/CoursePlaceController.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/courseplace/controller/CoursePlaceController.java
@@ -5,16 +5,18 @@ import com.comeon.courseservice.domain.courseplace.service.CoursePlaceService;
 import com.comeon.courseservice.domain.courseplace.service.dto.CoursePlaceDto;
 import com.comeon.courseservice.web.common.aop.ValidationRequired;
 import com.comeon.courseservice.web.common.response.ApiResponse;
+import com.comeon.courseservice.web.courseplace.request.CoursePlacesBatchSaveRequest;
 import com.comeon.courseservice.web.courseplace.request.CoursePlaceSaveRequest;
 import com.comeon.courseservice.web.courseplace.response.CoursePlaceSaveResponse;
+import com.comeon.courseservice.web.courseplace.response.CoursePlacesBatchSaveResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RestController
@@ -36,5 +38,22 @@ public class CoursePlaceController {
         Long coursePlaceId = coursePlaceService.saveCoursePlace(courseId, currentUserId, coursePlaceDto);
 
         return ApiResponse.createSuccess(new CoursePlaceSaveResponse(coursePlaceId));
+    }
+
+    // 코스 장소 리스트 등록
+    @ValidationRequired
+    @PostMapping("/batch")
+    public ApiResponse<CoursePlacesBatchSaveResponse> coursePlaceSaveBatch(@CurrentUserId Long currentUserId,
+                                                                           @Validated @RequestBody CoursePlacesBatchSaveRequest request,
+                                                                           BindingResult bindingResult) {
+        Long courseId = request.getCourseId();
+        List<CoursePlaceDto> coursePlaceDtos = request.getCoursePlaces().stream()
+                .map(CoursePlacesBatchSaveRequest.CoursePlaceInfo::toServiceDto)
+                .collect(Collectors.toList());
+
+        coursePlaceService.batchSaveCoursePlace(courseId, currentUserId, coursePlaceDtos);
+
+        // TODO 응답 값?
+        return ApiResponse.createSuccess(new CoursePlacesBatchSaveResponse());
     }
 }

--- a/course-service/src/main/java/com/comeon/courseservice/web/courseplace/controller/CoursePlaceController.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/courseplace/controller/CoursePlaceController.java
@@ -1,0 +1,35 @@
+package com.comeon.courseservice.web.courseplace.controller;
+
+import com.comeon.courseservice.domain.courseplace.service.CoursePlaceService;
+import com.comeon.courseservice.domain.courseplace.service.dto.CoursePlaceDto;
+import com.comeon.courseservice.web.common.aop.ValidationRequired;
+import com.comeon.courseservice.web.common.response.ApiResponse;
+import com.comeon.courseservice.web.courseplace.request.CoursePlaceSaveRequest;
+import com.comeon.courseservice.web.courseplace.response.CoursePlaceSaveResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/course-places")
+public class CoursePlaceController {
+
+    private final CoursePlaceService coursePlaceService;
+
+    // 코스 장소 등록
+    @ValidationRequired
+    @PostMapping
+    public ApiResponse<CoursePlaceSaveResponse> coursePlaceSave(@Validated CoursePlaceSaveRequest request) {
+        Long courseId = request.getCourseId();
+        CoursePlaceDto coursePlaceDto = request.toServiceDto();
+
+        Long coursePlaceId = coursePlaceService.saveCoursePlace(courseId, coursePlaceDto);
+
+        return ApiResponse.createSuccess(new CoursePlaceSaveResponse(coursePlaceId));
+    }
+}

--- a/course-service/src/main/java/com/comeon/courseservice/web/courseplace/controller/CoursePlaceController.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/courseplace/controller/CoursePlaceController.java
@@ -1,5 +1,6 @@
 package com.comeon.courseservice.web.courseplace.controller;
 
+import com.comeon.courseservice.config.argresolver.CurrentUserId;
 import com.comeon.courseservice.domain.courseplace.service.CoursePlaceService;
 import com.comeon.courseservice.domain.courseplace.service.dto.CoursePlaceDto;
 import com.comeon.courseservice.web.common.aop.ValidationRequired;
@@ -8,8 +9,10 @@ import com.comeon.courseservice.web.courseplace.request.CoursePlaceSaveRequest;
 import com.comeon.courseservice.web.courseplace.response.CoursePlaceSaveResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -24,11 +27,13 @@ public class CoursePlaceController {
     // 코스 장소 등록
     @ValidationRequired
     @PostMapping
-    public ApiResponse<CoursePlaceSaveResponse> coursePlaceSave(@Validated CoursePlaceSaveRequest request) {
+    public ApiResponse<CoursePlaceSaveResponse> coursePlaceSave(@CurrentUserId Long currentUserId,
+                                                                @Validated @RequestBody CoursePlaceSaveRequest request,
+                                                                BindingResult bindingResult) {
         Long courseId = request.getCourseId();
         CoursePlaceDto coursePlaceDto = request.toServiceDto();
 
-        Long coursePlaceId = coursePlaceService.saveCoursePlace(courseId, coursePlaceDto);
+        Long coursePlaceId = coursePlaceService.saveCoursePlace(courseId, currentUserId, coursePlaceDto);
 
         return ApiResponse.createSuccess(new CoursePlaceSaveResponse(coursePlaceId));
     }

--- a/course-service/src/main/java/com/comeon/courseservice/web/courseplace/request/CoursePlaceSaveRequest.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/courseplace/request/CoursePlaceSaveRequest.java
@@ -1,0 +1,28 @@
+package com.comeon.courseservice.web.courseplace.request;
+
+import com.comeon.courseservice.domain.courseplace.service.dto.CoursePlaceDto;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter @Setter
+@NoArgsConstructor
+public class CoursePlaceSaveRequest {
+    // TODO 검증 추가
+
+    private Long courseId;
+
+    private String name;
+    private String description;
+    private Double lat;
+    private Double lng;
+
+    public CoursePlaceDto toServiceDto() {
+        return CoursePlaceDto.builder()
+                .name(name)
+                .description(description)
+                .lat(lat)
+                .lng(lng)
+                .build();
+    }
+}

--- a/course-service/src/main/java/com/comeon/courseservice/web/courseplace/request/CoursePlaceSaveRequest.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/courseplace/request/CoursePlaceSaveRequest.java
@@ -1,15 +1,14 @@
 package com.comeon.courseservice.web.courseplace.request;
 
 import com.comeon.courseservice.domain.courseplace.service.dto.CoursePlaceDto;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
-@Getter @Setter
+@Getter
+@Setter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class CoursePlaceSaveRequest {

--- a/course-service/src/main/java/com/comeon/courseservice/web/courseplace/request/CoursePlaceSaveRequest.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/courseplace/request/CoursePlaceSaveRequest.java
@@ -1,20 +1,32 @@
 package com.comeon.courseservice.web.courseplace.request;
 
 import com.comeon.courseservice.domain.courseplace.service.dto.CoursePlaceDto;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
 @Getter @Setter
 @NoArgsConstructor
+@AllArgsConstructor
 public class CoursePlaceSaveRequest {
-    // TODO 검증 추가
 
+    @NotNull
     private Long courseId;
 
+    @NotBlank
     private String name;
+
+    @NotBlank
     private String description;
+
+    @NotNull
     private Double lat;
+
+    @NotNull
     private Double lng;
 
     public CoursePlaceDto toServiceDto() {

--- a/course-service/src/main/java/com/comeon/courseservice/web/courseplace/request/CoursePlacesBatchSaveRequest.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/courseplace/request/CoursePlacesBatchSaveRequest.java
@@ -1,0 +1,55 @@
+package com.comeon.courseservice.web.courseplace.request;
+
+import com.comeon.courseservice.domain.courseplace.service.dto.CoursePlaceDto;
+import lombok.*;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CoursePlacesBatchSaveRequest {
+
+    @NotNull
+    private Long courseId;
+
+    @Valid
+    @NotNull
+    private List<CoursePlaceInfo> coursePlaces;
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CoursePlaceInfo {
+
+        @NotBlank
+        private String name;
+
+        @NotBlank
+        private String description;
+
+        @NotNull
+        private Double lat;
+
+        @NotNull
+        private Double lng;
+
+        @NotNull
+        private Integer order;
+
+        public CoursePlaceDto toServiceDto() {
+            return CoursePlaceDto.builder()
+                    .name(name)
+                    .description(description)
+                    .lat(lat)
+                    .lng(lng)
+                    .order(order)
+                    .build();
+        }
+    }
+}

--- a/course-service/src/main/java/com/comeon/courseservice/web/courseplace/response/CoursePlaceSaveResponse.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/courseplace/response/CoursePlaceSaveResponse.java
@@ -1,0 +1,11 @@
+package com.comeon.courseservice.web.courseplace.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CoursePlaceSaveResponse {
+
+    private Long coursePlaceId;
+}

--- a/course-service/src/main/java/com/comeon/courseservice/web/courseplace/response/CoursePlacesBatchSaveResponse.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/courseplace/response/CoursePlacesBatchSaveResponse.java
@@ -1,0 +1,19 @@
+package com.comeon.courseservice.web.courseplace.response;
+
+import lombok.Getter;
+
+@Getter
+public class CoursePlacesBatchSaveResponse {
+
+    public static final String SUCCESS_MESSAGE = "코스 장소 리스트 저장이 완료되었습니다.";
+
+    private String message;
+
+    public CoursePlacesBatchSaveResponse() {
+        this.message = SUCCESS_MESSAGE;
+    }
+
+    public CoursePlacesBatchSaveResponse(String message) {
+        this.message = message;
+    }
+}

--- a/course-service/src/main/resources/errors.properties
+++ b/course-service/src/main/resources/errors.properties
@@ -9,6 +9,13 @@ NotBlank.coursePlaceSaveRequest.description=장소의 설명을 입력해주세�
 NotNull.coursePlaceSaveRequest.lat=장소의 위도 값을 입력해주세요.
 NotNull.coursePlaceSaveRequest.lng=장소의 경도 값을 입력해주세요.
 
+NotNull.coursePlacesBatchSaveRequest.courseId=장소를 등록할 코스의 식별값을 입력해주세요.
+NotBlank.coursePlacesBatchSaveRequest.coursePlaces.name=장소의 이름을 입력해주세요.
+NotBlank.coursePlacesBatchSaveRequest.coursePlaces.description=장소의 설명을 입력해주세요.
+NotNull.coursePlacesBatchSaveRequest.coursePlaces.lat=장소의 위도 값을 입력해주세요.
+NotNull.coursePlacesBatchSaveRequest.coursePlaces.lng=장소의 경도 값을 입력해주세요.
+NotNull.coursePlacesBatchSaveRequest.coursePlaces.order=장소의 순서를 입력해주세요.
+
 
 NotNull.imgFile=이미지 파일이 없습니다. 확인해주세요.
 NotBlank.title=제목은 비워둘 수 없습니다.
@@ -18,6 +25,7 @@ NotNull.courseId=코스 식별값을 입력해주세요.
 NotBlank.name=이름은 비워둘 수 없습니다.
 NotNull.lat=위도 값을 입력해주세요.
 NotNull.lng=경도 값을 입력해주세요.
+NotNull.order=순서를 입력해주세요.
 
 NotNull=비워둘 수 없습니다.
 NotBlank=공백이면 안됩니다. 값을 입력해주세요.

--- a/course-service/src/main/resources/errors.properties
+++ b/course-service/src/main/resources/errors.properties
@@ -1,0 +1,23 @@
+
+NotNull.courseSaveRequest.imgFile=코스 등록시, 이미지는 필수입니다.
+NotBlank.courseSaveRequest.title=등록할 코스의 제목을 입력해주세요.
+NotBlank.courseSaveRequest.description=등록할 코스의 설명을 입력해주세요.
+
+NotNull.coursePlaceSaveRequest.courseId=장소를 등록할 코스의 식별값을 입력해주세요.
+NotBlank.coursePlaceSaveRequest.name=장소의 이름을 입력해주세요.
+NotBlank.coursePlaceSaveRequest.description=장소의 설명을 입력해주세요.
+NotNull.coursePlaceSaveRequest.lat=장소의 위도 값을 입력해주세요.
+NotNull.coursePlaceSaveRequest.lng=장소의 경도 값을 입력해주세요.
+
+
+NotNull.imgFile=이미지 파일이 없습니다. 확인해주세요.
+NotBlank.title=제목은 비워둘 수 없습니다.
+NotBlank.description=설명은 비워둘 수 없습니다.
+
+NotNull.courseId=코스 식별값을 입력해주세요.
+NotBlank.name=이름은 비워둘 수 없습니다.
+NotNull.lat=위도 값을 입력해주세요.
+NotNull.lng=경도 값을 입력해주세요.
+
+NotNull=비워둘 수 없습니다.
+NotBlank=공백이면 안됩니다. 값을 입력해주세요.

--- a/course-service/src/main/resources/static/docs/index.html
+++ b/course-service/src/main/resources/static/docs/index.html
@@ -1,0 +1,1337 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.10">
+<title>Course Service API Docs</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+<style>
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
+/* Uncomment @import statement to use as custom stylesheet */
+/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
+article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section{display:block}
+audio,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
+a{background:none}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+abbr[title]{border-bottom:1px dotted}
+b,strong{font-weight:bold}
+dfn{font-style:italic}
+hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,*::before,*::after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:0}
+p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
+ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
+ul.square{list-style-type:square}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
+abbr{text-transform:none}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
+blockquote cite::before{content:"\2014 \0020"}
+blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
+table thead,table tfoot{background:#f7f8f7}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt{background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
+.clearfix::after,.float-group::after{clear:both}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
+:not(pre)>code.nobreak{word-wrap:normal}
+:not(pre)>code.nowrap{white-space:nowrap}
+pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
+pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
+pre>code{display:block}
+pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
+em em{font-style:normal}
+strong strong{font-weight:400}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
+b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
+b.button::before{content:"[";padding:0 3px 0 2px}
+b.button::after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
+#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
+#content{margin-top:1.25em}
+#content::before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span::before{content:"\00a0\2013\00a0"}
+#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark::before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber::after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
+@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:100%;background:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
+#content{margin-bottom:.625em}
+.sect1{padding-bottom:.625em}
+@media screen and (min-width:768px){#content{margin-bottom:1.25em}
+.sect1{padding-bottom:1.25em}}
+.sect1:last-child{padding-bottom:0}
+.sect1+.sect1{border-top:1px solid #e7e7e9}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+details>summary:first-of-type{cursor:pointer;display:list-item;outline:none;margin-bottom:.75em}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
+.paragraph.lead>p,#preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
+table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:inherit}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6)}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
+.exampleblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child{margin-bottom:0}
+.sidebarblock{border-style:solid;border-width:1px;border-color:#dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;-webkit-border-radius:4px;border-radius:4px}
+.sidebarblock>:first-child{margin-top:0}
+.sidebarblock>:last-child{margin-bottom:0}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock>.content>pre{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;overflow-x:auto;padding:1em;font-size:.8125em}
+@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
+@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
+.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class="highlight"],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
+.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
+.listingblock:hover code[data-lang]::before{display:block}
+.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
+.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.prettyprint{background:#f7f7f8}
+pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
+pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
+pre.prettyprint li code[data-lang]::before{opacity:1}
+pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
+table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
+table.linenotable td.code{padding-left:.75em}
+table.linenotable td.linenos{border-right:1px solid currentColor;opacity:.35;padding-right:.5em}
+pre.pygments .lineno{border-right:1px solid currentColor;opacity:.35;display:inline-block;margin-right:.75em}
+pre.pygments .lineno::before{content:"";margin-right:-.125em}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
+.verseblock{margin:0 1em 1.25em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
+.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
+.quoteblock.abstract{margin:0 1em 1.25em;display:block}
+.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
+.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
+.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
+.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;text-align:left;margin-right:0}
+table.tableblock{max-width:100%;border-collapse:separate}
+p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content>:last-child{margin-bottom:-1.25em}
+td.tableblock>.content>:last-child.sidebarblock{margin-bottom:0}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
+table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
+table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
+table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px}
+table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0}
+table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
+table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
+table.frame-all{border-width:1px}
+table.frame-sides{border-width:0 1px}
+table.frame-topbot,table.frame-ends{border-width:1px 0}
+table.stripes-all tr,table.stripes-odd tr:nth-of-type(odd),table.stripes-even tr:nth-of-type(even),table.stripes-hover tr:hover{background:#f8f8f7}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+ul.checklist{margin-left:.625em}
+ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
+ul.inline{display:-ms-flexbox;display:-webkit-box;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
+ul.inline>li{margin-left:1.25em}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
+.colist td:not([class]):first-child img{max-width:none}
+.colist td:not([class]):last-child{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
+.imageblock.left{margin:.25em .625em 1.25em 0}
+.imageblock.right{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
+.gist .file-data>table td.line-data{width:99%}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background:#00fafa}
+.black{color:#000}
+.black-background{background:#000}
+.blue{color:#0000bf}
+.blue-background{background:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background:#fa00fa}
+.gray{color:#606060}
+.gray-background{background:#7d7d7d}
+.green{color:#006000}
+.green-background{background:#007d00}
+.lime{color:#00bf00}
+.lime-background{background:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background:#7d0000}
+.navy{color:#000060}
+.navy-background{background:#00007d}
+.olive{color:#606000}
+.olive-background{background:#7d7d00}
+.purple{color:#600060}
+.purple-background{background:#7d007d}
+.red{color:#bf0000}
+.red-background{background:#fa0000}
+.silver{color:#909090}
+.silver-background{background:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background:#fafa00}
+span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]::after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@page{margin:1.25cm .75cm}
+@media print{*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
+html{font-size:80%}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]::after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span::before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]::before{display:block}
+#footer{padding:0 .9375em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+@media print,amzn-kf8{#header>h1:first-child{margin-top:1.25rem}
+.sect1{padding:0!important}
+.sect1+.sect1{border:0}
+#footer{background:none}
+#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
+@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+</style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+</head>
+<body class="book toc2 toc-left">
+<div id="header">
+<h1>Course Service API Docs</h1>
+<div class="details">
+<span id="revnumber">version 0.0.1-SNAPSHOT</span>
+</div>
+<div id="toc" class="toc2">
+<div id="toctitle">Course-Service API</div>
+<ul class="sectlevel1">
+<li><a href="#common">공통 스펙</a>
+<ul class="sectlevel3">
+<li><a href="#_공통_응답_스펙">공통 응답 스펙</a></li>
+<li><a href="#_공통_응답_스펙_예외인_경우">공통 응답 스펙 - 예외인 경우</a></li>
+</ul>
+</li>
+<li><a href="#_코스">코스</a>
+<ul class="sectlevel1">
+<li><a href="#Course-save">1. 코스 등록</a>
+<ul class="sectlevel2">
+<li><a href="#Normal">1) 정상 흐름</a></li>
+<li><a href="#Error">2) 예외</a></li>
+</ul>
+</li>
+<li><a href="#Course-Writing-Done">2. 코스 등록 완료</a>
+<ul class="sectlevel2">
+<li><a href="#Normal">1) 정상 흐름</a></li>
+<li><a href="#Error">2) 예외</a></li>
+</ul>
+</li>
+</ul>
+</li>
+<li><a href="#_코스_장소">코스 장소</a>
+<ul class="sectlevel1">
+<li><a href="#Course-Place-Save">1. 코스 장소 등록</a>
+<ul class="sectlevel2">
+<li><a href="#Normal">1) 정상 흐름</a></li>
+<li><a href="#Error">2) 예외</a></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</div>
+</div>
+<div id="content">
+<div class="sect1">
+<h2 id="common"><a class="link" href="#common">공통 스펙</a></h2>
+<div class="sectionbody">
+<div class="sect3">
+<h4 id="_공통_응답_스펙"><a class="link" href="#_공통_응답_스펙">공통 응답 스펙</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. 공통 응답 스펙</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">이름</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>responseTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 시간을 반환합니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드를 반환합니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 데이터를 반환합니다.</p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>Course-Service 응답메시지는 모두 위와 같은 스펙으로 구성되어 있습니다.</p>
+</div>
+<div class="sect4">
+<h5 id="_code_field_응답_코드_반환값"><a class="link" href="#_code_field_응답_코드_반환값">code field : 응답 코드 반환값</a></h5>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 2. 응답 코드</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">이름</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>BAD_PARAMETER</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">요청 파라미터가 잘못되었습니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>NOT_FOUND</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리소스를 찾지 못했습니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>SERVER_ERROR</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">서버 에러입니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>SUCCESS</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">요청이 성공하였습니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>UNAUTHORIZED</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">인증에 실패하였습니다.</p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>공통 응답 스펙의 <code>code</code> 필드에는 위와 같은 값들이 반환될 수 있습니다.<br>
+응답 코드는 <code>SUCCESS</code>인 경우를 제외하고 모두 예외가 발생한 상황입니다.</p>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_공통_응답_스펙_예외인_경우"><a class="link" href="#_공통_응답_스펙_예외인_경우">공통 응답 스펙 - 예외인 경우</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 3. 예외 응답 스펙</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">이름</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">API 내부에서 지정한 예외 코드를 반환합니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">예외 메시지를 반환합니다.</p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>예외가 발생한 경우에는 <code>data</code> 필드에 위와 같은 형식으로 발생한 예외에 대한 응답이 들어갑니다.<br>
+아래의 예시를 참고해주세요.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{
+  "responseTime" : "2022-08-28T03:58:02.213762",
+  "code" : "SERVER_ERROR",
+  "data" : {
+    "code" : 900,
+    "message" : "죄송합니다. 서버 내부 오류입니다."
+  }
+}</code></pre>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_errorcode_field_예외_응답_코드_반환값"><a class="link" href="#_errorcode_field_예외_응답_코드_반환값">errorCode field : 예외 응답 코드 반환값</a></h5>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 4. 예외 응답 코드</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">이름</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>900</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">죄송합니다. 서버 내부 오류입니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>901</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">파일이 비어있습니다. 확인해주세요.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>902</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">파일 업로드에 실패하였습니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>903</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">요청 데이터 검증에 실패하였습니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>904</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">해당 식별자를 가진 리소스가 없습니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>905</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">요청을 수행할 권한이 없습니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>907</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">인증된 사용자만이 이용 가능합니다.</p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>예외 응답 스펙의 <code>code</code> 필드에는 위와 같은 값들이 반환될 수 있습니다.</p>
+</div>
+</div>
+</div>
+</div>
+</div>
+<h1 id="_코스" class="sect0"><a class="link" href="#_코스">코스</a></h1>
+<div class="sect1">
+<h2 id="Course-save"><a class="link" href="#Course-save">1. 코스 등록</a></h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>POST /courses</p>
+</div>
+<div class="sect2">
+<h3 id="Normal"><a class="link" href="#Normal">1) 정상 흐름</a></h3>
+<div class="sect3">
+<h4 id="_요청_예시"><a class="link" href="#_요청_예시">요청 예시</a></h4>
+<div class="paragraph">
+<p>다음과 같이, 필수 데이터들을 모두 담아 요청하면, 요청을 성공적으로 처리하고 응답을 반환합니다.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /courses HTTP/1.1
+Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJhdXRoIjoiUk9MRV9VU0VSIiwiaXNzIjoidGVzdCIsImlhdCI6MTY2MTYyNjY5MCwiZXhwIjoxNjYxNjI2NzkwLCJzdWIiOiIxIn0.RwJPityCL9Xwkl2tNVjYs5_GqVuZV-7WMPo2Vg7rSqAnZvxQX3IR-5eF4aJy6O-K7n0GJxDat2UapAyPOSggng
+Host: localhost:8080
+
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Disposition: form-data; name=title
+
+courseTitle
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Disposition: form-data; name=description
+
+courseDescription
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Disposition: form-data; name=imgFile; filename=test-img2.png
+Content-Type: image/jpeg
+
+23r235r4tgq34gq34t
+c134tg235tg
+23v5t23v4gt342tf23
+4tg34td234tb3q45tcd234
+btq34gtf34ct234qbtq34gq
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm--</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_요청_헤더"><a class="link" href="#_요청_헤더">요청 헤더</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 5. 요청 헤더</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">헤더 이름</th>
+<th class="tableblock halign-left valign-top">필수값 여부</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">로그인 및 토큰 재발급을 통해 발급받은 Bearer AccessToken</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_요청_파라미터"><a class="link" href="#_요청_파라미터">요청 파라미터</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 6. 요청 파라미터</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">파라미터 이름</th>
+<th class="tableblock halign-left valign-top">필수값 여부</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">코스의 제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>description</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">코스의 설명</p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 7. 요청 파트</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">파트 이름</th>
+<th class="tableblock halign-left valign-top">필수값 여부</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>imgFile</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">등록할 이미지 파일</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_응답_예시"><a class="link" href="#_응답_예시">응답 예시</a></h4>
+<div class="paragraph">
+<p>요청을 성공적으로 처리하면 다음과 같은 응답을 반환합니다.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 110
+
+{
+  "responseTime" : "2022-08-28T03:58:11.162161",
+  "code" : "SUCCESS",
+  "data" : {
+    "courseId" : 4
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_응답_필드"><a class="link" href="#_응답_필드">응답 필드</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 8. 응답 필드</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>courseId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">저장된 코스의 식별값</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="Error"><a class="link" href="#Error">2) 예외</a></h3>
+<div class="sect3">
+<h4 id="_요청_예시_2"><a class="link" href="#_요청_예시_2">요청 예시</a></h4>
+<div class="paragraph">
+<p>다음과 같이 필수 데이터를 전송하지 않으면 예외가 발생하여 요청이 처리되지 않습니다.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /courses HTTP/1.1
+Content-Type: multipart/form-data;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJhdXRoIjoiUk9MRV9VU0VSIiwiaXNzIjoidGVzdCIsImlhdCI6MTY2MTYyNjY5MSwiZXhwIjoxNjYxNjI2NzkxLCJzdWIiOiIxIn0.61UWRffzehorCHK_FTupygUzPY9GSo_cprdeYl6-6Pq1sZvEZJSXKyZs-fwNfKfHG1m7SiQhZmXJ7Bf4sAvkmg
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_응답_예시_2"><a class="link" href="#_응답_예시_2">응답 예시</a></h4>
+<div class="paragraph">
+<p>요청 데이터 검증에 실패하면 다음과 같은 응답을 반환합니다.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Content-Type: application/json;charset=UTF-8
+Content-Length: 363
+
+{
+  "responseTime" : "2022-08-28T03:58:11.245509",
+  "code" : "BAD_PARAMETER",
+  "data" : {
+    "code" : 903,
+    "message" : {
+      "imgFile" : [ "코스 등록시, 이미지는 필수입니다." ],
+      "description" : [ "등록할 코스의 설명을 입력해주세요." ],
+      "title" : [ "등록할 코스의 제목을 입력해주세요." ]
+    }
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_응답_필드_2"><a class="link" href="#_응답_필드_2">응답 필드</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 9. 응답 필드</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">예외 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">예외 메시지</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="Course-Writing-Done"><a class="link" href="#Course-Writing-Done">2. 코스 등록 완료</a></h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>PATCH /courses/{courseId}/done</p>
+</div>
+<div class="sect2">
+<h3 id="Normal"><a class="link" href="#Normal">1) 정상 흐름</a></h3>
+<div class="sect3">
+<h4 id="_요청_예시_3"><a class="link" href="#_요청_예시_3">요청 예시</a></h4>
+<div class="paragraph">
+<p>다음과 같이, 요청한 유저가 등록한 코스의 식별자를 경로 변수로 전송하면, 요청을 성공적으로 처리합니다.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /courses/1/done HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJhdXRoIjoiUk9MRV9VU0VSIiwiaXNzIjoidGVzdCIsImlhdCI6MTY2MTYyNjY5MCwiZXhwIjoxNjYxNjI2NzkwLCJzdWIiOiIxIn0.RwJPityCL9Xwkl2tNVjYs5_GqVuZV-7WMPo2Vg7rSqAnZvxQX3IR-5eF4aJy6O-K7n0GJxDat2UapAyPOSggng
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_요청_헤더_2"><a class="link" href="#_요청_헤더_2">요청 헤더</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 10. 요청 헤더</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">헤더 이름</th>
+<th class="tableblock halign-left valign-top">필수값 여부</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">로그인 및 토큰 재발급을 통해 발급받은 Bearer AccessToken</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_요청_경로_파라미터"><a class="link" href="#_요청_경로_파라미터">요청 경로 파라미터</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 11. <code>/courses/{courseId}/done</code></caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">파라미터 이름</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>courseId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">대상 코스 식별값</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_응답_예시_3"><a class="link" href="#_응답_예시_3">응답 예시</a></h4>
+<div class="paragraph">
+<p>요청을 성공적으로 처리하면 다음과 같은 응답을 반환합니다.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 156
+
+{
+  "responseTime" : "2022-08-28T03:58:10.667234",
+  "code" : "SUCCESS",
+  "data" : {
+    "message" : "코스 등록 처리가 완료되었습니다."
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_응답_필드_3"><a class="link" href="#_응답_필드_3">응답 필드</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 12. 응답 필드</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">요청 처리 성공 메시지</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="Error"><a class="link" href="#Error">2) 예외</a></h3>
+<div class="sect3">
+<h4 id="_요청_예시_4"><a class="link" href="#_요청_예시_4">요청 예시</a></h4>
+<div class="paragraph">
+<p>다음과 같이, 경로 변수 <code>{courseId}</code>로 존재하지 않는 코스의 식별자가 넘어오면<br>
+예외가 발생하여 요청이 처리되지 않습니다.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /courses/100/done HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJhdXRoIjoiUk9MRV9VU0VSIiwiaXNzIjoidGVzdCIsImlhdCI6MTY2MTYyNjY5MCwiZXhwIjoxNjYxNjI2NzkwLCJzdWIiOiIxIn0.RwJPityCL9Xwkl2tNVjYs5_GqVuZV-7WMPo2Vg7rSqAnZvxQX3IR-5eF4aJy6O-K7n0GJxDat2UapAyPOSggng
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_응답_예시_4"><a class="link" href="#_응답_예시_4">응답 예시</a></h4>
+<div class="paragraph">
+<p>해당 예외가 발생하여 요청이 실패하면, 다음과 같은 응답을 반환합니다.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Content-Type: application/json;charset=UTF-8
+Content-Length: 186
+
+{
+  "responseTime" : "2022-08-28T03:58:10.847023",
+  "code" : "SERVER_ERROR",
+  "data" : {
+    "code" : 904,
+    "message" : "해당 식별자를 가진 리소스가 없습니다."
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_응답_필드_4"><a class="link" href="#_응답_필드_4">응답 필드</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 13. 응답 필드</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">예외 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">예외 메시지</p></td>
+</tr>
+</tbody>
+</table>
+<hr>
+</div>
+</div>
+</div>
+</div>
+<h1 id="_코스_장소" class="sect0"><a class="link" href="#_코스_장소">코스 장소</a></h1>
+<div class="sect1">
+<h2 id="Course-Place-Save"><a class="link" href="#Course-Place-Save">1. 코스 장소 등록</a></h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>POST /course-place</p>
+</div>
+<div class="sect2">
+<h3 id="Normal"><a class="link" href="#Normal">1) 정상 흐름</a></h3>
+<div class="sect3">
+<h4 id="_요청_예시_5"><a class="link" href="#_요청_예시_5">요청 예시</a></h4>
+<div class="paragraph">
+<p>다음과 같이, 필수 데이터들을 모두 포함하여 요청하면, 요청을 성공적으로 처리하고 응답을 반환합니다.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /course-places HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJhdXRoIjoiUk9MRV9VU0VSIiwiaXNzIjoidGVzdCIsImlhdCI6MTY2MTYyNjY5MSwiZXhwIjoxNjYxNjI2NzkxLCJzdWIiOiIxIn0.61UWRffzehorCHK_FTupygUzPY9GSo_cprdeYl6-6Pq1sZvEZJSXKyZs-fwNfKfHG1m7SiQhZmXJ7Bf4sAvkmg
+Content-Length: 116
+Host: localhost:8080
+
+{
+  "courseId" : 5,
+  "name" : "placeName",
+  "description" : "placeDescription",
+  "lat" : 12.34,
+  "lng" : 34.56
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_요청_헤더_3"><a class="link" href="#_요청_헤더_3">요청 헤더</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 14. 요청 헤더</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">헤더 이름</th>
+<th class="tableblock halign-left valign-top">필수값 여부</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">로그인 및 토큰 재발급을 통해 발급받은 Bearer AccessToken</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_요청_파라미터_2"><a class="link" href="#_요청_파라미터_2">요청 파라미터</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 15. 요청 필드</caption>
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>courseId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">대상 코스의 식별값</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">장소 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>description</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">장소의 설명</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>lat</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">장소의 위도값</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>lng</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">장소의 경도값</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_응답_예시_5"><a class="link" href="#_응답_예시_5">응답 예시</a></h4>
+<div class="paragraph">
+<p>요청을 성공적으로 처리하면 다음과 같은 응답을 반환합니다.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 115
+
+{
+  "responseTime" : "2022-08-28T03:58:11.439117",
+  "code" : "SUCCESS",
+  "data" : {
+    "coursePlaceId" : 2
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_응답_필드_5"><a class="link" href="#_응답_필드_5">응답 필드</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 16. 응답 필드</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>coursePlaceId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">저장된 코스 장소 식별값</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="Error"><a class="link" href="#Error">2) 예외</a></h3>
+<div class="sect3">
+<h4 id="_요청_예시_6"><a class="link" href="#_요청_예시_6">요청 예시</a></h4>
+<div class="paragraph">
+<p>다음과 같이 필수 데이터를 전송하지 않으면 예외가 발생하여 요청이 처리되지 않습니다.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /course-places HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJhdXRoIjoiUk9MRV9VU0VSIiwiaXNzIjoidGVzdCIsImlhdCI6MTY2MTYyNjY5MSwiZXhwIjoxNjYxNjI2NzkxLCJzdWIiOiIxIn0.61UWRffzehorCHK_FTupygUzPY9GSo_cprdeYl6-6Pq1sZvEZJSXKyZs-fwNfKfHG1m7SiQhZmXJ7Bf4sAvkmg
+Content-Length: 96
+Host: localhost:8080
+
+{
+  "courseId" : null,
+  "name" : null,
+  "description" : null,
+  "lat" : null,
+  "lng" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_응답_예시_6"><a class="link" href="#_응답_예시_6">응답 예시</a></h4>
+<div class="paragraph">
+<p>요청 데이터 검증에 실패하면 다음과 같은 응답을 반환합니다.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Content-Type: application/json;charset=UTF-8
+Content-Length: 488
+
+{
+  "responseTime" : "2022-08-28T03:58:11.490629",
+  "code" : "BAD_PARAMETER",
+  "data" : {
+    "code" : 903,
+    "message" : {
+      "courseId" : [ "장소를 등록할 코스의 식별값을 입력해주세요." ],
+      "lng" : [ "장소의 경도 값을 입력해주세요." ],
+      "lat" : [ "장소의 위도 값을 입력해주세요." ],
+      "name" : [ "장소의 이름을 입력해주세요." ],
+      "description" : [ "장소의 설명을 입력해주세요." ]
+    }
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_응답_필드_6"><a class="link" href="#_응답_필드_6">응답 필드</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 17. 응답 필드</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">예외 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">예외 메시지</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Version 0.0.1-SNAPSHOT<br>
+Last updated 2022-08-28 03:57:13 +0900
+</div>
+</div>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/highlight.min.js"></script>
+<script>hljs.initHighlighting()</script>
+</body>
+</html>

--- a/course-service/src/main/resources/static/docs/index.html
+++ b/course-service/src/main/resources/static/docs/index.html
@@ -456,14 +456,8 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <ul class="sectlevel1">
 <li><a href="#Course-save">1. 코스 등록</a>
 <ul class="sectlevel2">
-<li><a href="#Normal">1) 정상 흐름</a></li>
-<li><a href="#Error">2) 예외</a></li>
-</ul>
-</li>
-<li><a href="#Course-Writing-Done">2. 코스 등록 완료</a>
-<ul class="sectlevel2">
-<li><a href="#Normal">1) 정상 흐름</a></li>
-<li><a href="#Error">2) 예외</a></li>
+<li><a href="#Course-save-Normal">1) 정상 흐름</a></li>
+<li><a href="#Course-save-Error">2) 예외</a></li>
 </ul>
 </li>
 </ul>
@@ -472,8 +466,14 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <ul class="sectlevel1">
 <li><a href="#Course-Place-Save">1. 코스 장소 등록</a>
 <ul class="sectlevel2">
-<li><a href="#Normal">1) 정상 흐름</a></li>
-<li><a href="#Error">2) 예외</a></li>
+<li><a href="#Course-Place-Save-Normal">1) 정상 흐름</a></li>
+<li><a href="#Course-Place-Save-Error">2) 예외</a></li>
+</ul>
+</li>
+<li><a href="#Course-Place-Save-Batch">2. 코스 장소 리스트 등록</a>
+<ul class="sectlevel2">
+<li><a href="#Course-Place-Save-Batch-Normal">1) 정상 흐름</a></li>
+<li><a href="#Course-Place-Save-Batch-Error">2) 예외</a></li>
 </ul>
 </li>
 </ul>
@@ -592,7 +592,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-none hljs">{
-  "responseTime" : "2022-08-28T03:58:02.213762",
+  "responseTime" : "2022-08-29T15:11:03.702036",
   "code" : "SERVER_ERROR",
   "data" : {
     "code" : 900,
@@ -661,7 +661,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <p>POST /courses</p>
 </div>
 <div class="sect2">
-<h3 id="Normal"><a class="link" href="#Normal">1) 정상 흐름</a></h3>
+<h3 id="Course-save-Normal"><a class="link" href="#Course-save-Normal">1) 정상 흐름</a></h3>
 <div class="sect3">
 <h4 id="_요청_예시"><a class="link" href="#_요청_예시">요청 예시</a></h4>
 <div class="paragraph">
@@ -671,7 +671,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /courses HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJhdXRoIjoiUk9MRV9VU0VSIiwiaXNzIjoidGVzdCIsImlhdCI6MTY2MTYyNjY5MCwiZXhwIjoxNjYxNjI2NzkwLCJzdWIiOiIxIn0.RwJPityCL9Xwkl2tNVjYs5_GqVuZV-7WMPo2Vg7rSqAnZvxQX3IR-5eF4aJy6O-K7n0GJxDat2UapAyPOSggng
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJhdXRoIjoiUk9MRV9VU0VSIiwiaXNzIjoidGVzdCIsImlhdCI6MTY2MTc1MzQ3MiwiZXhwIjoxNjYxNzUzNTcyLCJzdWIiOiIxIn0.LQeKZ7GB6upxGngZvFk3YZmppAha3PaXo9kX-I6cINFgYc1bvSyiYu-qw2whcgHpqV08EwM8BKxKtEfDrLZ-qA
 Host: localhost:8080
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -784,10 +784,10 @@ Content-Type: application/json;charset=UTF-8
 Content-Length: 110
 
 {
-  "responseTime" : "2022-08-28T03:58:11.162161",
+  "responseTime" : "2022-08-29T15:11:12.319665",
   "code" : "SUCCESS",
   "data" : {
-    "courseId" : 4
+    "courseId" : 1
   }
 }</code></pre>
 </div>
@@ -820,7 +820,7 @@ Content-Length: 110
 </div>
 </div>
 <div class="sect2">
-<h3 id="Error"><a class="link" href="#Error">2) 예외</a></h3>
+<h3 id="Course-save-Error"><a class="link" href="#Course-save-Error">2) 예외</a></h3>
 <div class="sect3">
 <h4 id="_요청_예시_2"><a class="link" href="#_요청_예시_2">요청 예시</a></h4>
 <div class="paragraph">
@@ -830,7 +830,7 @@ Content-Length: 110
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /courses HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJhdXRoIjoiUk9MRV9VU0VSIiwiaXNzIjoidGVzdCIsImlhdCI6MTY2MTYyNjY5MSwiZXhwIjoxNjYxNjI2NzkxLCJzdWIiOiIxIn0.61UWRffzehorCHK_FTupygUzPY9GSo_cprdeYl6-6Pq1sZvEZJSXKyZs-fwNfKfHG1m7SiQhZmXJ7Bf4sAvkmg
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJhdXRoIjoiUk9MRV9VU0VSIiwiaXNzIjoidGVzdCIsImlhdCI6MTY2MTc1MzQ3MiwiZXhwIjoxNjYxNzUzNTcyLCJzdWIiOiIxIn0.LQeKZ7GB6upxGngZvFk3YZmppAha3PaXo9kX-I6cINFgYc1bvSyiYu-qw2whcgHpqV08EwM8BKxKtEfDrLZ-qA
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -847,14 +847,14 @@ Content-Type: application/json;charset=UTF-8
 Content-Length: 363
 
 {
-  "responseTime" : "2022-08-28T03:58:11.245509",
+  "responseTime" : "2022-08-29T15:11:12.449879",
   "code" : "BAD_PARAMETER",
   "data" : {
     "code" : 903,
     "message" : {
+      "title" : [ "등록할 코스의 제목을 입력해주세요." ],
       "imgFile" : [ "코스 등록시, 이미지는 필수입니다." ],
-      "description" : [ "등록할 코스의 설명을 입력해주세요." ],
-      "title" : [ "등록할 코스의 제목을 입력해주세요." ]
+      "description" : [ "등록할 코스의 설명을 입력해주세요." ]
     }
   }
 }</code></pre>
@@ -890,28 +890,40 @@ Content-Length: 363
 </tr>
 </tbody>
 </table>
+<hr>
 </div>
 </div>
 </div>
 </div>
+<h1 id="_코스_장소" class="sect0"><a class="link" href="#_코스_장소">코스 장소</a></h1>
 <div class="sect1">
-<h2 id="Course-Writing-Done"><a class="link" href="#Course-Writing-Done">2. 코스 등록 완료</a></h2>
+<h2 id="Course-Place-Save"><a class="link" href="#Course-Place-Save">1. 코스 장소 등록</a></h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>PATCH /courses/{courseId}/done</p>
+<p>POST /course-place</p>
 </div>
 <div class="sect2">
-<h3 id="Normal"><a class="link" href="#Normal">1) 정상 흐름</a></h3>
+<h3 id="Course-Place-Save-Normal"><a class="link" href="#Course-Place-Save-Normal">1) 정상 흐름</a></h3>
 <div class="sect3">
 <h4 id="_요청_예시_3"><a class="link" href="#_요청_예시_3">요청 예시</a></h4>
 <div class="paragraph">
-<p>다음과 같이, 요청한 유저가 등록한 코스의 식별자를 경로 변수로 전송하면, 요청을 성공적으로 처리합니다.</p>
+<p>다음과 같이, 필수 데이터들을 모두 포함하여 요청하면, 요청을 성공적으로 처리하고 응답을 반환합니다.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /courses/1/done HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJhdXRoIjoiUk9MRV9VU0VSIiwiaXNzIjoidGVzdCIsImlhdCI6MTY2MTYyNjY5MCwiZXhwIjoxNjYxNjI2NzkwLCJzdWIiOiIxIn0.RwJPityCL9Xwkl2tNVjYs5_GqVuZV-7WMPo2Vg7rSqAnZvxQX3IR-5eF4aJy6O-K7n0GJxDat2UapAyPOSggng
-Host: localhost:8080</code></pre>
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /course-places HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJhdXRoIjoiUk9MRV9VU0VSIiwiaXNzIjoidGVzdCIsImlhdCI6MTY2MTc1MzQ3MiwiZXhwIjoxNjYxNzUzNTcyLCJzdWIiOiIxIn0.LQeKZ7GB6upxGngZvFk3YZmppAha3PaXo9kX-I6cINFgYc1bvSyiYu-qw2whcgHpqV08EwM8BKxKtEfDrLZ-qA
+Content-Length: 116
+Host: localhost:8080
+
+{
+  "courseId" : 7,
+  "name" : "placeName",
+  "description" : "placeDescription",
+  "lat" : 12.34,
+  "lng" : 34.56
+}</code></pre>
 </div>
 </div>
 </div>
@@ -941,207 +953,9 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_요청_경로_파라미터"><a class="link" href="#_요청_경로_파라미터">요청 경로 파라미터</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 11. <code>/courses/{courseId}/done</code></caption>
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">파라미터 이름</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>courseId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">대상 코스 식별값</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_응답_예시_3"><a class="link" href="#_응답_예시_3">응답 예시</a></h4>
-<div class="paragraph">
-<p>요청을 성공적으로 처리하면 다음과 같은 응답을 반환합니다.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
-Content-Length: 156
-
-{
-  "responseTime" : "2022-08-28T03:58:10.667234",
-  "code" : "SUCCESS",
-  "data" : {
-    "message" : "코스 등록 처리가 완료되었습니다."
-  }
-}</code></pre>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_응답_필드_3"><a class="link" href="#_응답_필드_3">응답 필드</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 12. 응답 필드</caption>
-<colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">타입</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">요청 처리 성공 메시지</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-<div class="sect2">
-<h3 id="Error"><a class="link" href="#Error">2) 예외</a></h3>
-<div class="sect3">
-<h4 id="_요청_예시_4"><a class="link" href="#_요청_예시_4">요청 예시</a></h4>
-<div class="paragraph">
-<p>다음과 같이, 경로 변수 <code>{courseId}</code>로 존재하지 않는 코스의 식별자가 넘어오면<br>
-예외가 발생하여 요청이 처리되지 않습니다.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /courses/100/done HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJhdXRoIjoiUk9MRV9VU0VSIiwiaXNzIjoidGVzdCIsImlhdCI6MTY2MTYyNjY5MCwiZXhwIjoxNjYxNjI2NzkwLCJzdWIiOiIxIn0.RwJPityCL9Xwkl2tNVjYs5_GqVuZV-7WMPo2Vg7rSqAnZvxQX3IR-5eF4aJy6O-K7n0GJxDat2UapAyPOSggng
-Host: localhost:8080</code></pre>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_응답_예시_4"><a class="link" href="#_응답_예시_4">응답 예시</a></h4>
-<div class="paragraph">
-<p>해당 예외가 발생하여 요청이 실패하면, 다음과 같은 응답을 반환합니다.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
-Content-Type: application/json;charset=UTF-8
-Content-Length: 186
-
-{
-  "responseTime" : "2022-08-28T03:58:10.847023",
-  "code" : "SERVER_ERROR",
-  "data" : {
-    "code" : 904,
-    "message" : "해당 식별자를 가진 리소스가 없습니다."
-  }
-}</code></pre>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_응답_필드_4"><a class="link" href="#_응답_필드_4">응답 필드</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 13. 응답 필드</caption>
-<colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">타입</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">예외 코드</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">예외 메시지</p></td>
-</tr>
-</tbody>
-</table>
-<hr>
-</div>
-</div>
-</div>
-</div>
-<h1 id="_코스_장소" class="sect0"><a class="link" href="#_코스_장소">코스 장소</a></h1>
-<div class="sect1">
-<h2 id="Course-Place-Save"><a class="link" href="#Course-Place-Save">1. 코스 장소 등록</a></h2>
-<div class="sectionbody">
-<div class="paragraph">
-<p>POST /course-place</p>
-</div>
-<div class="sect2">
-<h3 id="Normal"><a class="link" href="#Normal">1) 정상 흐름</a></h3>
-<div class="sect3">
-<h4 id="_요청_예시_5"><a class="link" href="#_요청_예시_5">요청 예시</a></h4>
-<div class="paragraph">
-<p>다음과 같이, 필수 데이터들을 모두 포함하여 요청하면, 요청을 성공적으로 처리하고 응답을 반환합니다.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /course-places HTTP/1.1
-Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJhdXRoIjoiUk9MRV9VU0VSIiwiaXNzIjoidGVzdCIsImlhdCI6MTY2MTYyNjY5MSwiZXhwIjoxNjYxNjI2NzkxLCJzdWIiOiIxIn0.61UWRffzehorCHK_FTupygUzPY9GSo_cprdeYl6-6Pq1sZvEZJSXKyZs-fwNfKfHG1m7SiQhZmXJ7Bf4sAvkmg
-Content-Length: 116
-Host: localhost:8080
-
-{
-  "courseId" : 5,
-  "name" : "placeName",
-  "description" : "placeDescription",
-  "lat" : 12.34,
-  "lng" : 34.56
-}</code></pre>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_요청_헤더_3"><a class="link" href="#_요청_헤더_3">요청 헤더</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 14. 요청 헤더</caption>
-<colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">헤더 이름</th>
-<th class="tableblock halign-left valign-top">필수값 여부</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">로그인 및 토큰 재발급을 통해 발급받은 Bearer AccessToken</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
 <h4 id="_요청_파라미터_2"><a class="link" href="#_요청_파라미터_2">요청 파라미터</a></h4>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 15. 요청 필드</caption>
+<caption class="title">Table 11. 요청 필드</caption>
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -1191,7 +1005,7 @@ Host: localhost:8080
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_예시_5"><a class="link" href="#_응답_예시_5">응답 예시</a></h4>
+<h4 id="_응답_예시_3"><a class="link" href="#_응답_예시_3">응답 예시</a></h4>
 <div class="paragraph">
 <p>요청을 성공적으로 처리하면 다음과 같은 응답을 반환합니다.</p>
 </div>
@@ -1202,19 +1016,19 @@ Content-Type: application/json;charset=UTF-8
 Content-Length: 115
 
 {
-  "responseTime" : "2022-08-28T03:58:11.439117",
+  "responseTime" : "2022-08-29T15:11:13.014849",
   "code" : "SUCCESS",
   "data" : {
-    "coursePlaceId" : 2
+    "coursePlaceId" : 1
   }
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_응답_필드_5"><a class="link" href="#_응답_필드_5">응답 필드</a></h4>
+<h4 id="_응답_필드_3"><a class="link" href="#_응답_필드_3">응답 필드</a></h4>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 16. 응답 필드</caption>
+<caption class="title">Table 12. 응답 필드</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -1238,9 +1052,9 @@ Content-Length: 115
 </div>
 </div>
 <div class="sect2">
-<h3 id="Error"><a class="link" href="#Error">2) 예외</a></h3>
+<h3 id="Course-Place-Save-Error"><a class="link" href="#Course-Place-Save-Error">2) 예외</a></h3>
 <div class="sect3">
-<h4 id="_요청_예시_6"><a class="link" href="#_요청_예시_6">요청 예시</a></h4>
+<h4 id="_요청_예시_4"><a class="link" href="#_요청_예시_4">요청 예시</a></h4>
 <div class="paragraph">
 <p>다음과 같이 필수 데이터를 전송하지 않으면 예외가 발생하여 요청이 처리되지 않습니다.</p>
 </div>
@@ -1248,7 +1062,7 @@ Content-Length: 115
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /course-places HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJhdXRoIjoiUk9MRV9VU0VSIiwiaXNzIjoidGVzdCIsImlhdCI6MTY2MTYyNjY5MSwiZXhwIjoxNjYxNjI2NzkxLCJzdWIiOiIxIn0.61UWRffzehorCHK_FTupygUzPY9GSo_cprdeYl6-6Pq1sZvEZJSXKyZs-fwNfKfHG1m7SiQhZmXJ7Bf4sAvkmg
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJhdXRoIjoiUk9MRV9VU0VSIiwiaXNzIjoidGVzdCIsImlhdCI6MTY2MTc1MzQ3MywiZXhwIjoxNjYxNzUzNTczLCJzdWIiOiIxIn0.HNSji_g4d9n486pqAfoERo-QebCWPdiPKF7mJ-5PVdOMROnvnxJq4E6_jh7KfEVG6ehASM7TnbkKV0z5s9Bkzw
 Content-Length: 96
 Host: localhost:8080
 
@@ -1263,7 +1077,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_응답_예시_6"><a class="link" href="#_응답_예시_6">응답 예시</a></h4>
+<h4 id="_응답_예시_4"><a class="link" href="#_응답_예시_4">응답 예시</a></h4>
 <div class="paragraph">
 <p>요청 데이터 검증에 실패하면 다음과 같은 응답을 반환합니다.</p>
 </div>
@@ -1274,16 +1088,370 @@ Content-Type: application/json;charset=UTF-8
 Content-Length: 488
 
 {
-  "responseTime" : "2022-08-28T03:58:11.490629",
+  "responseTime" : "2022-08-29T15:11:13.077507",
   "code" : "BAD_PARAMETER",
   "data" : {
     "code" : 903,
     "message" : {
       "courseId" : [ "장소를 등록할 코스의 식별값을 입력해주세요." ],
+      "name" : [ "장소의 이름을 입력해주세요." ],
       "lng" : [ "장소의 경도 값을 입력해주세요." ],
       "lat" : [ "장소의 위도 값을 입력해주세요." ],
-      "name" : [ "장소의 이름을 입력해주세요." ],
       "description" : [ "장소의 설명을 입력해주세요." ]
+    }
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_응답_필드_4"><a class="link" href="#_응답_필드_4">응답 필드</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 13. 응답 필드</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">예외 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">예외 메시지</p></td>
+</tr>
+</tbody>
+</table>
+<hr>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="Course-Place-Save-Batch"><a class="link" href="#Course-Place-Save-Batch">2. 코스 장소 리스트 등록</a></h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>POST /course-place/batch</p>
+</div>
+<div class="sect2">
+<h3 id="Course-Place-Save-Batch-Normal"><a class="link" href="#Course-Place-Save-Batch-Normal">1) 정상 흐름</a></h3>
+<div class="sect3">
+<h4 id="_요청_예시_5"><a class="link" href="#_요청_예시_5">요청 예시</a></h4>
+<div class="paragraph">
+<p>다음과 같이, 필수 데이터들을 모두 포함하여 요청하면, 요청을 성공적으로 처리하고 응답을 반환합니다.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /course-places/batch HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJhdXRoIjoiUk9MRV9VU0VSIiwiaXNzIjoidGVzdCIsImlhdCI6MTY2MTc1MzQ3MiwiZXhwIjoxNjYxNzUzNTcyLCJzdWIiOiIxIn0.LQeKZ7GB6upxGngZvFk3YZmppAha3PaXo9kX-I6cINFgYc1bvSyiYu-qw2whcgHpqV08EwM8BKxKtEfDrLZ-qA
+Content-Length: 688
+Host: localhost:8080
+
+{
+  "courseId" : 3,
+  "coursePlaces" : [ {
+    "name" : "placeName1",
+    "description" : "placeDescription1",
+    "lat" : 13.34,
+    "lng" : 35.56,
+    "order" : 1
+  }, {
+    "name" : "placeName2",
+    "description" : "placeDescription2",
+    "lat" : 14.34,
+    "lng" : 36.56,
+    "order" : 2
+  }, {
+    "name" : "placeName3",
+    "description" : "placeDescription3",
+    "lat" : 15.34,
+    "lng" : 37.56,
+    "order" : 3
+  }, {
+    "name" : "placeName4",
+    "description" : "placeDescription4",
+    "lat" : 16.34,
+    "lng" : 38.56,
+    "order" : 4
+  }, {
+    "name" : "placeName5",
+    "description" : "placeDescription5",
+    "lat" : 17.34,
+    "lng" : 39.56,
+    "order" : 5
+  } ]
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_요청_헤더_3"><a class="link" href="#_요청_헤더_3">요청 헤더</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 14. 요청 헤더</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">헤더 이름</th>
+<th class="tableblock halign-left valign-top">필수값 여부</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">로그인 및 토큰 재발급을 통해 발급받은 Bearer AccessToken</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_요청_파라미터_3"><a class="link" href="#_요청_파라미터_3">요청 파라미터</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 15. 요청 필드</caption>
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>courseId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">대상 코스의 식별값</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>coursePlaces</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">대상 코스에 등록할 장소 리스트</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>coursePlaces[].name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">장소 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>coursePlaces[].description</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">장소의 설명</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>coursePlaces[].lat</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">장소의 위도값</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>coursePlaces[].lng</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">장소의 경도값</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>coursePlaces[].order</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">장소의 순서</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_응답_예시_5"><a class="link" href="#_응답_예시_5">응답 예시</a></h4>
+<div class="paragraph">
+<p>요청을 성공적으로 처리하면 다음과 같은 응답을 반환합니다.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 166
+
+{
+  "responseTime" : "2022-08-29T15:11:12.775886",
+  "code" : "SUCCESS",
+  "data" : {
+    "message" : "코스 장소 리스트 저장이 완료되었습니다."
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_응답_필드_5"><a class="link" href="#_응답_필드_5">응답 필드</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 16. 응답 필드</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">장소 리스트 저장 성공 메시지</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="Course-Place-Save-Batch-Error"><a class="link" href="#Course-Place-Save-Batch-Error">2) 예외</a></h3>
+<div class="sect3">
+<h4 id="_요청_예시_1"><a class="link" href="#_요청_예시_1">요청 예시 1</a></h4>
+<div class="paragraph">
+<p>다음과 같이 필수 데이터인 장소를 하나도 전송하지 않으면
+예외가 발생하여 요청이 처리되지 않습니다.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /course-places/batch HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJhdXRoIjoiUk9MRV9VU0VSIiwiaXNzIjoidGVzdCIsImlhdCI6MTY2MTc1MzQ3MiwiZXhwIjoxNjYxNzUzNTcyLCJzdWIiOiIxIn0.LQeKZ7GB6upxGngZvFk3YZmppAha3PaXo9kX-I6cINFgYc1bvSyiYu-qw2whcgHpqV08EwM8BKxKtEfDrLZ-qA
+Content-Length: 45
+Host: localhost:8080
+
+{
+  "courseId" : 5,
+  "coursePlaces" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_응답_예시_1"><a class="link" href="#_응답_예시_1">응답 예시 1</a></h4>
+<div class="paragraph">
+<p>요청 데이터 검증에 실패하면 다음과 같은 응답을 반환합니다.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Content-Type: application/json;charset=UTF-8
+Content-Length: 196
+
+{
+  "responseTime" : "2022-08-29T15:11:12.883497",
+  "code" : "BAD_PARAMETER",
+  "data" : {
+    "code" : 903,
+    "message" : {
+      "coursePlaces" : [ "비워둘 수 없습니다." ]
+    }
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_요청_예시_2_2"><a class="link" href="#_요청_예시_2_2">요청 예시 2</a></h4>
+<div class="paragraph">
+<p>다음과 같이, 장소 리스트 중 특정 필드를 입력하지 않은 경우,
+예외가 발생하여 요청이 처리되지 않습니다.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /course-places/batch HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJhdXRoIjoiUk9MRV9VU0VSIiwiaXNzIjoidGVzdCIsImlhdCI6MTY2MTc1MzQ3MiwiZXhwIjoxNjYxNzUzNTcyLCJzdWIiOiIxIn0.LQeKZ7GB6upxGngZvFk3YZmppAha3PaXo9kX-I6cINFgYc1bvSyiYu-qw2whcgHpqV08EwM8BKxKtEfDrLZ-qA
+Content-Length: 691
+Host: localhost:8080
+
+{
+  "courseId" : 6,
+  "coursePlaces" : [ {
+    "name" : "placeName1",
+    "description" : "placeDescription1",
+    "lat" : null,
+    "lng" : 35.56,
+    "order" : 1
+  }, {
+    "name" : "placeName2",
+    "description" : "placeDescription2",
+    "lat" : 14.34,
+    "lng" : 36.56,
+    "order" : null
+  }, {
+    "name" : "placeName3",
+    "description" : "placeDescription3",
+    "lat" : null,
+    "lng" : 37.56,
+    "order" : 3
+  }, {
+    "name" : "placeName4",
+    "description" : "placeDescription4",
+    "lat" : 16.34,
+    "lng" : 38.56,
+    "order" : null
+  }, {
+    "name" : "placeName5",
+    "description" : "placeDescription5",
+    "lat" : null,
+    "lng" : 39.56,
+    "order" : 5
+  } ]
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_응답_예시_2_2"><a class="link" href="#_응답_예시_2_2">응답 예시 2</a></h4>
+<div class="paragraph">
+<p>요청 데이터 검증에 실패하면 다음과 같은 응답을 반환합니다.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 400 Bad Request
+Content-Type: application/json;charset=UTF-8
+Content-Length: 539
+
+{
+  "responseTime" : "2022-08-29T15:11:12.929797",
+  "code" : "BAD_PARAMETER",
+  "data" : {
+    "code" : 903,
+    "message" : {
+      "coursePlaces[4].lat" : [ "장소의 위도 값을 입력해주세요." ],
+      "coursePlaces[0].lat" : [ "장소의 위도 값을 입력해주세요." ],
+      "coursePlaces[2].lat" : [ "장소의 위도 값을 입력해주세요." ],
+      "coursePlaces[3].order" : [ "장소의 순서를 입력해주세요." ],
+      "coursePlaces[1].order" : [ "장소의 순서를 입력해주세요." ]
     }
   }
 }</code></pre>
@@ -1327,7 +1495,7 @@ Content-Length: 488
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2022-08-28 03:57:13 +0900
+Last updated 2022-08-29 15:10:19 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/course-service/src/test/java/com/comeon/courseservice/config/S3MockConfig.java
+++ b/course-service/src/test/java/com/comeon/courseservice/config/S3MockConfig.java
@@ -1,0 +1,58 @@
+package com.comeon.courseservice.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import io.findify.s3mock.S3Mock;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+@Slf4j
+@TestConfiguration
+public class S3MockConfig {
+
+    @Value("${cloud.aws.region.static}")
+    String region;
+
+    @Value("${cloud.aws.s3.bucket}")
+    String bucket;
+
+    @Bean
+    public S3Mock s3Mock() {
+        return new S3Mock.Builder()
+                .withPort(8001)
+                .withInMemoryBackend()
+                .build();
+    }
+
+    @Bean
+    @Primary
+    public AmazonS3 amazonS3(S3Mock s3Mock) {
+        log.info("[amazonS3Config] start");
+        s3Mock.start();
+
+        AwsClientBuilder.EndpointConfiguration endpoint =
+                new AwsClientBuilder.EndpointConfiguration("http://127.0.0.1:8001", region);
+
+        AmazonS3 client = AmazonS3ClientBuilder
+                .standard()
+                .withPathStyleAccessEnabled(true)
+                .withEndpointConfiguration(endpoint)
+                .withCredentials(
+                        new AWSStaticCredentialsProvider(
+                                new AnonymousAWSCredentials()
+                        )
+                )
+                .build();
+
+        client.createBucket(bucket);
+
+        log.info("[amazonS3Config] end");
+        return client;
+    }
+}

--- a/course-service/src/test/java/com/comeon/courseservice/docs/CommonResponseRestDocsTest.java
+++ b/course-service/src/test/java/com/comeon/courseservice/docs/CommonResponseRestDocsTest.java
@@ -1,0 +1,120 @@
+package com.comeon.courseservice.docs;
+
+import com.comeon.courseservice.docs.config.CommonRestDocsSupport;
+import com.comeon.courseservice.docs.utils.RestDocsUtil;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.Map;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.snippet.Attributes.attributes;
+import static org.springframework.restdocs.snippet.Attributes.key;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Slf4j
+@SpringBootTest
+@AutoConfigureMockMvc
+public class CommonResponseRestDocsTest extends CommonRestDocsSupport {
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("API 공통 응답")
+    void commonResponse() throws Exception {
+        ResultActions perform = mockMvc.perform(
+                get("/docs/success").accept(MediaType.APPLICATION_JSON)
+        );
+
+        Map<String, String> data = (Map<String, String>) objectMapper
+                .readValue(perform.andReturn()
+                                .getResponse()
+                                .getContentAsByteArray(),
+                        new TypeReference<Map<String, Object>>() {}
+                )
+                .get("data");
+
+        perform.andExpect(status().isOk())
+                .andDo(
+                        restDocs.document(
+                                RestDocsUtil.customResponseFields(
+                                        "common-response", null,
+                                        attributes(key("title").value("공통 응답 스펙")),
+                                        fieldWithPath("responseTime").description("응답 시간을 반환합니다."),
+                                        fieldWithPath("code").description("응답 코드를 반환합니다."),
+                                        subsectionWithPath("data").description("결과 데이터를 반환합니다.")
+                                ),
+                                RestDocsUtil.customResponseFields(
+                                        "common-response", beneathPath("data").withSubsectionId("code"),
+                                        attributes(key("title").value("응답 코드")),
+                                        enumConvertFieldDescriptor(data)
+                                )
+                        )
+                );
+    }
+
+    @Test
+    @DisplayName("API 예외 응답")
+    void errorResponse() throws Exception {
+        ResultActions perform = mockMvc.perform(
+                get("/docs/error").accept(MediaType.APPLICATION_JSON)
+        );
+
+        perform.andExpect(status().isBadRequest())
+                .andDo(
+                        restDocs.document(
+                                RestDocsUtil.customResponseFields(
+                                        "common-response", beneathPath("data").withSubsectionId("error"),
+                                        attributes(key("title").value("예외 응답 스펙")),
+                                        fieldWithPath("code").description("API 내부에서 지정한 예외 코드를 반환합니다."),
+                                        fieldWithPath("message").description("예외 메시지를 반환합니다.")
+                                )
+                        )
+                );
+    }
+
+    @Test
+    @DisplayName("API 예외 응답 코드")
+    void errorCode() throws Exception {
+        ResultActions perform = mockMvc.perform(
+                get("/docs/error/codes").accept(MediaType.APPLICATION_JSON)
+        );
+
+        Map<String, String> data = (Map<String, String>) objectMapper
+                .readValue(perform.andReturn()
+                                .getResponse()
+                                .getContentAsByteArray(),
+                        new TypeReference<Map<String, Object>>() {}
+                )
+                .get("data");
+
+        perform.andDo(
+                restDocs.document(
+                        RestDocsUtil.customResponseFields(
+                                "common-response", beneathPath("data").withSubsectionId("error-codes"),
+                                attributes(key("title").value("예외 응답 코드")),
+                                enumConvertFieldDescriptor(data)
+                        )
+                )
+        );
+    }
+
+    private static FieldDescriptor[] enumConvertFieldDescriptor(Map<String, String> enumValues) {
+        return enumValues.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(x -> fieldWithPath(x.getKey()).description(x.getValue()))
+                .toArray(FieldDescriptor[]::new);
+    }
+}

--- a/course-service/src/test/java/com/comeon/courseservice/docs/config/CommonRestDocsController.java
+++ b/course-service/src/test/java/com/comeon/courseservice/docs/config/CommonRestDocsController.java
@@ -1,0 +1,40 @@
+package com.comeon.courseservice.docs.config;
+
+import com.comeon.courseservice.common.exception.ErrorCode;
+import com.comeon.courseservice.web.common.response.ApiResponse;
+import com.comeon.courseservice.web.common.response.ApiResponseCode;
+import com.comeon.courseservice.web.common.response.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RestController
+public class CommonRestDocsController {
+
+    @GetMapping("/docs/success")
+    public ApiResponse<?> commonResponseFields() {
+        Map<String, String> responseCodes = Arrays.stream(ApiResponseCode.values())
+                .collect(Collectors.toMap(ApiResponseCode::getId, ApiResponseCode::getText));
+
+        return ApiResponse.createSuccess(responseCodes);
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @GetMapping("/docs/error")
+    public ApiResponse<ErrorResponse> commonErrorResponseFields() {
+        return ApiResponse.createServerError(ErrorCode.SERVER_ERROR);
+    }
+
+    @GetMapping("/docs/error/codes")
+    public ApiResponse<?> errorResponseCodes() {
+        Map<Integer, String> errorCodes = Arrays.stream(ErrorCode.values())
+                .collect(Collectors.toMap(ErrorCode::getCode, ErrorCode::getMessage));
+        return ApiResponse.createSuccess(errorCodes);
+    }
+
+}

--- a/course-service/src/test/java/com/comeon/courseservice/docs/config/CommonRestDocsSupport.java
+++ b/course-service/src/test/java/com/comeon/courseservice/docs/config/CommonRestDocsSupport.java
@@ -1,0 +1,39 @@
+package com.comeon.courseservice.docs.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+@Disabled
+@Import(RestDocsConfig.class)
+@ExtendWith(RestDocumentationExtension.class)
+public class CommonRestDocsSupport {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected RestDocumentationResultHandler restDocs;
+
+    @BeforeEach
+    void setUp(final WebApplicationContext context,
+               final RestDocumentationContextProvider provider) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(MockMvcRestDocumentation.documentationConfiguration(provider))
+                .alwaysDo(MockMvcResultHandlers.print())
+                .alwaysDo(restDocs)
+                .addFilters(new CharacterEncodingFilter("UTF-8", true))
+                .build();
+    }
+}

--- a/course-service/src/test/java/com/comeon/courseservice/docs/config/RestDocsConfig.java
+++ b/course-service/src/test/java/com/comeon/courseservice/docs/config/RestDocsConfig.java
@@ -1,0 +1,20 @@
+package com.comeon.courseservice.docs.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
+
+@TestConfiguration
+public class RestDocsConfig {
+
+    @Bean
+    public RestDocumentationResultHandler write() {
+        return MockMvcRestDocumentation.document(
+                "{class-name}/{method-name}",
+                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                Preprocessors.preprocessResponse(Preprocessors.prettyPrint())
+        );
+    }
+}

--- a/course-service/src/test/java/com/comeon/courseservice/docs/config/RestDocsSupport.java
+++ b/course-service/src/test/java/com/comeon/courseservice/docs/config/RestDocsSupport.java
@@ -1,0 +1,47 @@
+package com.comeon.courseservice.docs.config;
+
+import com.comeon.courseservice.config.argresolver.JwtArgumentResolver;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+@AutoConfigureMockMvc
+@Import(RestDocsConfig.class)
+@ExtendWith(RestDocumentationExtension.class)
+public class RestDocsSupport {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected RestDocumentationResultHandler restDocs;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @Autowired
+    JwtArgumentResolver jwtArgumentResolver;
+
+    @BeforeEach
+    void setUp(final WebApplicationContext context,
+               final RestDocumentationContextProvider provider) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(MockMvcRestDocumentation.documentationConfiguration(provider))
+//                .alwaysDo(MockMvcResultHandlers.print())
+//                .alwaysDo(restDocs)
+                .addFilters(new CharacterEncodingFilter("UTF-8", true))
+                .build();
+    }
+}

--- a/course-service/src/test/java/com/comeon/courseservice/docs/utils/RestDocsUtil.java
+++ b/course-service/src/test/java/com/comeon/courseservice/docs/utils/RestDocsUtil.java
@@ -1,0 +1,23 @@
+package com.comeon.courseservice.docs.utils;
+
+import com.comeon.courseservice.docs.utils.snippets.CustomResponseFieldsSnippet;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.PayloadSubsectionExtractor;
+
+import java.util.Arrays;
+import java.util.Map;
+
+public class RestDocsUtil {
+
+    public static CustomResponseFieldsSnippet customResponseFields(
+            String type, PayloadSubsectionExtractor<?> subsectionExtractor,
+            Map<String, Object> attributes, FieldDescriptor... descriptors) {
+
+        return new CustomResponseFieldsSnippet(
+                type, subsectionExtractor,
+                Arrays.asList(descriptors),
+                attributes, true
+        );
+    }
+
+}

--- a/course-service/src/test/java/com/comeon/courseservice/docs/utils/snippets/CustomResponseFieldsSnippet.java
+++ b/course-service/src/test/java/com/comeon/courseservice/docs/utils/snippets/CustomResponseFieldsSnippet.java
@@ -1,0 +1,31 @@
+package com.comeon.courseservice.docs.utils.snippets;
+
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.operation.Operation;
+import org.springframework.restdocs.payload.AbstractFieldsSnippet;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.PayloadSubsectionExtractor;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class CustomResponseFieldsSnippet extends AbstractFieldsSnippet {
+
+    public CustomResponseFieldsSnippet(String type, PayloadSubsectionExtractor<?> subsectionExtractor,
+                                       List<FieldDescriptor> descriptors, Map<String, Object> attributes,
+                                       boolean ignoreUndocumentedFields) {
+        super(type, descriptors, attributes, ignoreUndocumentedFields, subsectionExtractor);
+    }
+
+    @Override
+    protected MediaType getContentType(Operation operation) {
+        return operation.getResponse().getHeaders().getContentType();
+    }
+
+    @Override
+    protected byte[] getContent(Operation operation) throws IOException {
+        return operation.getResponse().getContent();
+    }
+
+}

--- a/course-service/src/test/java/com/comeon/courseservice/domain/course/service/CourseServiceTest.java
+++ b/course-service/src/test/java/com/comeon/courseservice/domain/course/service/CourseServiceTest.java
@@ -1,15 +1,11 @@
 package com.comeon.courseservice.domain.course.service;
 
-import com.comeon.courseservice.common.exception.CustomException;
-import com.comeon.courseservice.common.exception.ErrorCode;
-import com.comeon.courseservice.domain.common.exception.EntityNotFoundException;
 import com.comeon.courseservice.domain.course.entity.Course;
 import com.comeon.courseservice.domain.course.entity.CourseImage;
 import com.comeon.courseservice.domain.course.entity.CourseWriteStatus;
 import com.comeon.courseservice.domain.course.repository.CourseRepository;
 import com.comeon.courseservice.domain.course.service.dto.CourseDto;
 import com.comeon.courseservice.domain.course.service.dto.CourseImageDto;
-import com.comeon.courseservice.domain.courseplace.entity.CoursePlace;
 import com.comeon.courseservice.domain.courseplace.repository.CoursePlaceRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -21,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.persistence.EntityManager;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @Transactional
@@ -102,101 +97,5 @@ class CourseServiceTest {
 
             assertThat(course.getCoursePlaces().size()).isEqualTo(0);
         }
-    }
-
-    @Nested
-    @DisplayName("코스 작성 완료")
-    class completeWritingCourse {
-
-        @Test
-        @DisplayName("코스 장소가 등록되어 있으면, 코스 작성 상태를 완료로 변경한다.")
-        void success() {
-            // given
-            initCourse();
-            Long userId = course.getUserId();
-            Long courseId = course.getId();
-
-            CoursePlace coursePlace = CoursePlace.builder()
-                    .course(course)
-                    .name("placeName")
-                    .description("placeDescription")
-                    .lat(1.1)
-                    .lng(1.3)
-                    .order(1)
-                    .build();
-            coursePlaceRepository.save(coursePlace);
-            em.flush();
-            em.clear();
-
-            // when
-            courseService.completeWritingCourse(courseId, userId);
-            em.flush();
-            em.clear();
-
-            // then
-            Course findCourse = courseRepository.findById(courseId).orElse(null);
-            assertThat(findCourse).isNotNull();
-            assertThat(findCourse.getWriteStatus()).isNotEqualTo(CourseWriteStatus.WRITING);
-            assertThat(findCourse.getWriteStatus()).isEqualTo(CourseWriteStatus.COMPLETE);
-        }
-    }
-
-    @Test
-    @DisplayName("등록된 코스 장소가 하나도 없으면, ErrorCode.VALIDATION_FAIL 필드를 가진 CustomException 예외가 발생한다.")
-    void fail_1() {
-        // given
-        initCourse();
-        Long userId = course.getUserId();
-        Long courseId = course.getId();
-        em.flush();
-        em.clear();
-
-        // when, then
-        assertThatThrownBy(
-                () -> courseService.completeWritingCourse(courseId, userId)
-        )
-                .isInstanceOf(CustomException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.VALIDATION_FAIL);
-    }
-
-    @Test
-    @DisplayName("코스를 등록한 유저와 상태 변경하려는 유저가 다르면, ErrorCode.NO_AUTHORITIES 필드를 가진 CustomException 예외가 발생한다.")
-    void fail_2() {
-        // given
-        initCourse();
-        Long invalidUserId = 100L;
-        Long courseId = course.getId();
-
-        CoursePlace coursePlace = CoursePlace.builder()
-                .course(course)
-                .name("placeName")
-                .description("placeDescription")
-                .lat(1.1)
-                .lng(1.3)
-                .order(1)
-                .build();
-        coursePlaceRepository.save(coursePlace);
-        em.flush();
-        em.clear();
-
-        // when, then
-        assertThatThrownBy(
-                () -> courseService.completeWritingCourse(courseId, invalidUserId)
-        )
-                .isInstanceOf(CustomException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NO_AUTHORITIES);
-    }
-
-    @Test
-    @DisplayName("파라미터로 넘어온 courseId와 일치하는 코스 식별자가 없으면, EntityNotFoundException 예외를 발생시킨다.")
-    void fail_3() {
-        // given
-        Long invalidCourseId = 100L;
-        Long userId = 1L;
-
-        // when, then
-        assertThatThrownBy(
-                () -> courseService.completeWritingCourse(invalidCourseId, userId)
-        ).isInstanceOf(EntityNotFoundException.class);
     }
 }

--- a/course-service/src/test/java/com/comeon/courseservice/domain/course/service/CourseServiceTest.java
+++ b/course-service/src/test/java/com/comeon/courseservice/domain/course/service/CourseServiceTest.java
@@ -1,0 +1,202 @@
+package com.comeon.courseservice.domain.course.service;
+
+import com.comeon.courseservice.common.exception.CustomException;
+import com.comeon.courseservice.common.exception.ErrorCode;
+import com.comeon.courseservice.domain.common.exception.EntityNotFoundException;
+import com.comeon.courseservice.domain.course.entity.Course;
+import com.comeon.courseservice.domain.course.entity.CourseImage;
+import com.comeon.courseservice.domain.course.entity.CourseWriteStatus;
+import com.comeon.courseservice.domain.course.repository.CourseRepository;
+import com.comeon.courseservice.domain.course.service.dto.CourseDto;
+import com.comeon.courseservice.domain.course.service.dto.CourseImageDto;
+import com.comeon.courseservice.domain.courseplace.entity.CoursePlace;
+import com.comeon.courseservice.domain.courseplace.repository.CoursePlaceRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+class CourseServiceTest {
+
+    @Autowired
+    CourseService courseService;
+
+    @Autowired
+    CourseRepository courseRepository;
+
+    @Autowired
+    CoursePlaceRepository coursePlaceRepository;
+
+    @Autowired
+    EntityManager em;
+
+    Course course;
+
+    void initCourse() {
+        Long userId = 1L;
+        String title = "courseTitle";
+        String description = "courseDescription";
+        CourseImage courseImage = CourseImage.builder()
+                .originalName("originalName")
+                .storedName("storedName")
+                .build();
+
+        Course courseToSave = Course.builder()
+                .userId(userId)
+                .title(title)
+                .description(description)
+                .courseImage(courseImage)
+                .build();
+        course = courseRepository.save(courseToSave);
+    }
+
+    @Nested
+    @DisplayName("코스 등록 - 코스 이미지, 코스 제목, 코스 설명, 유저 아이디가 주어진다")
+    class saveCourse {
+
+        @Test
+        @DisplayName("코스 등록에 성공하면, 등록된 코스의 식별값을 반환한다. 코스는 작성중 상태로 저장된다.")
+        void success() {
+            // given
+            Long userId = 1L;
+            String title = "courseTitle";
+            String description = "courseDescription";
+            CourseImageDto courseImageDto = CourseImageDto.builder()
+                    .originalName("originalName")
+                    .storedName("storedName")
+                    .build();
+
+            CourseDto courseDto = CourseDto.builder()
+                    .userId(userId)
+                    .title(title)
+                    .description(description)
+                    .courseImageDto(courseImageDto)
+                    .build();
+
+            // when
+            Long savedCourseId = courseService.saveCourse(courseDto);
+
+            // then
+            Course course = courseRepository.findById(savedCourseId).orElse(null);
+            assertThat(course).isNotNull();
+            assertThat(course.getTitle()).isEqualTo(title);
+            assertThat(course.getDescription()).isEqualTo(description);
+            assertThat(course.getUserId()).isEqualTo(userId);
+
+            assertThat(course.getCourseImage()).isNotNull();
+            assertThat(course.getCourseImage().getId()).isNotNull();
+            assertThat(course.getCourseImage().getOriginalName()).isEqualTo(courseImageDto.getOriginalName());
+            assertThat(course.getCourseImage().getStoredName()).isEqualTo(courseImageDto.getStoredName());
+
+            // 등록된 코스는 작성중 상태여야 한다.
+            assertThat(course.getWriteStatus()).isEqualTo(CourseWriteStatus.WRITING);
+
+            assertThat(course.getCoursePlaces().size()).isEqualTo(0);
+        }
+    }
+
+    @Nested
+    @DisplayName("코스 작성 완료")
+    class completeWritingCourse {
+
+        @Test
+        @DisplayName("코스 장소가 등록되어 있으면, 코스 작성 상태를 완료로 변경한다.")
+        void success() {
+            // given
+            initCourse();
+            Long userId = course.getUserId();
+            Long courseId = course.getId();
+
+            CoursePlace coursePlace = CoursePlace.builder()
+                    .course(course)
+                    .name("placeName")
+                    .description("placeDescription")
+                    .lat(1.1)
+                    .lng(1.3)
+                    .order(1)
+                    .build();
+            coursePlaceRepository.save(coursePlace);
+            em.flush();
+            em.clear();
+
+            // when
+            courseService.completeWritingCourse(courseId, userId);
+            em.flush();
+            em.clear();
+
+            // then
+            Course findCourse = courseRepository.findById(courseId).orElse(null);
+            assertThat(findCourse).isNotNull();
+            assertThat(findCourse.getWriteStatus()).isNotEqualTo(CourseWriteStatus.WRITING);
+            assertThat(findCourse.getWriteStatus()).isEqualTo(CourseWriteStatus.COMPLETE);
+        }
+    }
+
+    @Test
+    @DisplayName("등록된 코스 장소가 하나도 없으면, ErrorCode.VALIDATION_FAIL 필드를 가진 CustomException 예외가 발생한다.")
+    void fail_1() {
+        // given
+        initCourse();
+        Long userId = course.getUserId();
+        Long courseId = course.getId();
+        em.flush();
+        em.clear();
+
+        // when, then
+        assertThatThrownBy(
+                () -> courseService.completeWritingCourse(courseId, userId)
+        )
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.VALIDATION_FAIL);
+    }
+
+    @Test
+    @DisplayName("코스를 등록한 유저와 상태 변경하려는 유저가 다르면, ErrorCode.NO_AUTHORITIES 필드를 가진 CustomException 예외가 발생한다.")
+    void fail_2() {
+        // given
+        initCourse();
+        Long invalidUserId = 100L;
+        Long courseId = course.getId();
+
+        CoursePlace coursePlace = CoursePlace.builder()
+                .course(course)
+                .name("placeName")
+                .description("placeDescription")
+                .lat(1.1)
+                .lng(1.3)
+                .order(1)
+                .build();
+        coursePlaceRepository.save(coursePlace);
+        em.flush();
+        em.clear();
+
+        // when, then
+        assertThatThrownBy(
+                () -> courseService.completeWritingCourse(courseId, invalidUserId)
+        )
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NO_AUTHORITIES);
+    }
+
+    @Test
+    @DisplayName("파라미터로 넘어온 courseId와 일치하는 코스 식별자가 없으면, EntityNotFoundException 예외를 발생시킨다.")
+    void fail_3() {
+        // given
+        Long invalidCourseId = 100L;
+        Long userId = 1L;
+
+        // when, then
+        assertThatThrownBy(
+                () -> courseService.completeWritingCourse(invalidCourseId, userId)
+        ).isInstanceOf(EntityNotFoundException.class);
+    }
+}

--- a/course-service/src/test/java/com/comeon/courseservice/domain/courseplace/service/CoursePlaceServiceTest.java
+++ b/course-service/src/test/java/com/comeon/courseservice/domain/courseplace/service/CoursePlaceServiceTest.java
@@ -1,0 +1,150 @@
+package com.comeon.courseservice.domain.courseplace.service;
+
+import com.comeon.courseservice.common.exception.CustomException;
+import com.comeon.courseservice.common.exception.ErrorCode;
+import com.comeon.courseservice.domain.common.exception.EntityNotFoundException;
+import com.comeon.courseservice.domain.course.entity.Course;
+import com.comeon.courseservice.domain.course.entity.CourseImage;
+import com.comeon.courseservice.domain.course.repository.CourseRepository;
+import com.comeon.courseservice.domain.courseplace.entity.CoursePlace;
+import com.comeon.courseservice.domain.courseplace.repository.CoursePlaceRepository;
+import com.comeon.courseservice.domain.courseplace.service.dto.CoursePlaceDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+class CoursePlaceServiceTest {
+
+    @Autowired
+    CoursePlaceService coursePlaceService;
+
+    @Autowired
+    CourseRepository courseRepository;
+
+    @Autowired
+    CoursePlaceRepository coursePlaceRepository;
+
+    @Autowired
+    EntityManager em;
+
+    Course course;
+
+    void initCourse() {
+        Long userId = 1L;
+        String title = "courseTitle";
+        String description = "courseDescription";
+        CourseImage courseImage = CourseImage.builder()
+                .originalName("originalName")
+                .storedName("storedName")
+                .build();
+
+        Course courseToSave = Course.builder()
+                .userId(userId)
+                .title(title)
+                .description(description)
+                .courseImage(courseImage)
+                .build();
+        course = courseRepository.save(courseToSave);
+    }
+
+    @Nested
+    @DisplayName("코스 장소 등록")
+    class saveCoursePlace {
+
+        @Test
+        @DisplayName("코스를 등록한 유저가 장소를 등록하면, 코스 장소 등록에 성공한다.")
+        void success() {
+            // given
+            initCourse();
+            Long userId = course.getUserId();
+            Long courseId = course.getId();
+
+            String placeName = "placeName";
+            String placeDescription = "placeDescription";
+            Double placeLat = 12.34;
+            Double placeLng = 34.56;
+            CoursePlaceDto coursePlaceDto = CoursePlaceDto.builder()
+                    .name(placeName)
+                    .description(placeDescription)
+                    .lat(placeLat)
+                    .lng(placeLng)
+                    .build();
+
+            // when
+            Long coursePlaceId = coursePlaceService.saveCoursePlace(courseId, userId, coursePlaceDto);
+
+            // then
+            CoursePlace coursePlace = coursePlaceRepository.findById(coursePlaceId).orElse(null);
+            assertThat(coursePlace).isNotNull();
+            assertThat(coursePlace.getCourse()).isEqualTo(course);
+            assertThat(coursePlace.getName()).isEqualTo(coursePlaceDto.getName());
+            assertThat(coursePlace.getDescription()).isEqualTo(coursePlaceDto.getDescription());
+            assertThat(coursePlace.getLat()).isEqualTo(coursePlaceDto.getLat());
+            assertThat(coursePlace.getLng()).isEqualTo(coursePlaceDto.getLng());
+            assertThat(coursePlace.getOrder()).isNotNull();
+            if (coursePlace.getCourse().getCoursePlaces().size() == 1) {
+                assertThat(coursePlace.getOrder()).isEqualTo(1);
+            }
+        }
+
+        @Test
+        @DisplayName("파라미터로 넘어온 userId가 코스를 등록한 유저와 다르면, ErrorCode.NO_AUTHORITIES 를 갖는 CustomException 발생한다.")
+        void fail() {
+            // given
+            initCourse();
+            Long invalidUserId = 100L;
+            Long courseId = course.getId();
+
+            String placeName = "placeName";
+            String placeDescription = "placeDescription";
+            Double placeLat = 12.34;
+            Double placeLng = 34.56;
+            CoursePlaceDto coursePlaceDto = CoursePlaceDto.builder()
+                    .name(placeName)
+                    .description(placeDescription)
+                    .lat(placeLat)
+                    .lng(placeLng)
+                    .build();
+
+            // when, then
+            assertThatThrownBy(
+                    () -> coursePlaceService.saveCoursePlace(courseId, invalidUserId, coursePlaceDto)
+            )
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NO_AUTHORITIES);
+        }
+
+        @Test
+        @DisplayName("파라미터로 넘어온 courseId와 일치하는 코스 식별자가 없으면, EntityNotFoundException 예외를 발생시킨다.")
+        void fail_2() {
+            // given
+            String placeName = "placeName";
+            String placeDescription = "placeDescription";
+            Double placeLat = 12.34;
+            Double placeLng = 34.56;
+            CoursePlaceDto coursePlaceDto = CoursePlaceDto.builder()
+                    .name(placeName)
+                    .description(placeDescription)
+                    .lat(placeLat)
+                    .lng(placeLng)
+                    .build();
+            Long invalidCourseId = 100L;
+            Long userId = 1L;
+
+            // when, then
+            assertThatThrownBy(
+                    () -> coursePlaceService.saveCoursePlace(invalidCourseId, userId, coursePlaceDto)
+            ).isInstanceOf(EntityNotFoundException.class);
+        }
+    }
+}

--- a/course-service/src/test/java/com/comeon/courseservice/domain/courseplace/service/CoursePlaceServiceTest.java
+++ b/course-service/src/test/java/com/comeon/courseservice/domain/courseplace/service/CoursePlaceServiceTest.java
@@ -5,6 +5,7 @@ import com.comeon.courseservice.common.exception.ErrorCode;
 import com.comeon.courseservice.domain.common.exception.EntityNotFoundException;
 import com.comeon.courseservice.domain.course.entity.Course;
 import com.comeon.courseservice.domain.course.entity.CourseImage;
+import com.comeon.courseservice.domain.course.entity.CourseWriteStatus;
 import com.comeon.courseservice.domain.course.repository.CourseRepository;
 import com.comeon.courseservice.domain.courseplace.entity.CoursePlace;
 import com.comeon.courseservice.domain.courseplace.repository.CoursePlaceRepository;
@@ -17,6 +18,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -144,6 +148,133 @@ class CoursePlaceServiceTest {
             // when, then
             assertThatThrownBy(
                     () -> coursePlaceService.saveCoursePlace(invalidCourseId, userId, coursePlaceDto)
+            ).isInstanceOf(EntityNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("코스 장소 리스트 등록")
+    class batchSaveCoursePlace {
+
+        @Test
+        @DisplayName("코스를 등록한 유저가 장소 리스트를 등록하면, 코스 장소 리스트 등록에 성공하고, 코스의 작성 상태를 COMPLETE로 변경한다.")
+        void success() {
+            // given
+            initCourse();
+            Long userId = course.getUserId();
+            Long courseId = course.getId();
+
+            int count = 5;
+
+            String placeName = "placeName";
+            String placeDescription = "placeDescription";
+            Double placeLat = 12.34;
+            Double placeLng = 34.56;
+            List<CoursePlaceDto> coursePlaceDtoList = new ArrayList<>();
+
+            for (int i = 1; i <= count; i++) {
+                coursePlaceDtoList.add(
+                        CoursePlaceDto.builder()
+                                .name(placeName + i)
+                                .description(placeDescription + i)
+                                .lat(placeLat + i)
+                                .lng(placeLng + i)
+                                .order(i)
+                                .build()
+                );
+            }
+
+            // when
+            coursePlaceService.batchSaveCoursePlace(courseId, userId, coursePlaceDtoList);
+            em.flush();
+            em.clear();
+
+            // then
+            Course findCourse = courseRepository.findById(courseId).orElseThrow();
+            assertThat(findCourse.getWriteStatus()).isEqualTo(CourseWriteStatus.COMPLETE);
+            List<CoursePlace> coursePlaces = findCourse.getCoursePlaces();
+            assertThat(coursePlaces.size()).isEqualTo(coursePlaceDtoList.size());
+            for (CoursePlaceDto coursePlaceDto : coursePlaceDtoList) {
+                CoursePlace matchCoursePlace = coursePlaces.stream()
+                        .filter(coursePlace -> coursePlace.getOrder().equals(coursePlaceDto.getOrder()))
+                        .findFirst()
+                        .orElse(null);
+
+                assertThat(matchCoursePlace).isNotNull();
+                assertThat(matchCoursePlace.getCourse()).isEqualTo(findCourse);
+                assertThat(matchCoursePlace.getName()).isEqualTo(coursePlaceDto.getName());
+                assertThat(matchCoursePlace.getDescription()).isEqualTo(coursePlaceDto.getDescription());
+                assertThat(matchCoursePlace.getLat()).isEqualTo(coursePlaceDto.getLat());
+                assertThat(matchCoursePlace.getLng()).isEqualTo(coursePlaceDto.getLng());
+            }
+        }
+
+        @Test
+        @DisplayName("파라미터로 넘어온 userId가 코스를 등록한 유저와 다르면, ErrorCode.NO_AUTHORITIES 를 갖는 CustomException 발생한다.")
+        void fail() {
+            // given
+            initCourse();
+            Long invalidUserId = 100L;
+            Long courseId = course.getId();
+
+            int count = 5;
+
+            String placeName = "placeName";
+            String placeDescription = "placeDescription";
+            Double placeLat = 12.34;
+            Double placeLng = 34.56;
+            List<CoursePlaceDto> coursePlaceDtoList = new ArrayList<>();
+
+            for (int i = 1; i <= count; i++) {
+                coursePlaceDtoList.add(
+                        CoursePlaceDto.builder()
+                                .name(placeName + i)
+                                .description(placeDescription + i)
+                                .lat(placeLat + i)
+                                .lng(placeLng + i)
+                                .order(i)
+                                .build()
+                );
+            }
+
+            // when, then
+            assertThatThrownBy(
+                    () -> coursePlaceService.batchSaveCoursePlace(courseId, invalidUserId, coursePlaceDtoList)
+            )
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NO_AUTHORITIES);
+        }
+
+        @Test
+        @DisplayName("파라미터로 넘어온 courseId와 일치하는 코스 식별자가 없으면, EntityNotFoundException 예외를 발생시킨다.")
+        void fail_2() {
+            // given
+            Long invalidCourseId = 100L;
+            Long userId = 1L;
+
+            int count = 5;
+
+            String placeName = "placeName";
+            String placeDescription = "placeDescription";
+            Double placeLat = 12.34;
+            Double placeLng = 34.56;
+            List<CoursePlaceDto> coursePlaceDtoList = new ArrayList<>();
+
+            for (int i = 1; i <= count; i++) {
+                coursePlaceDtoList.add(
+                        CoursePlaceDto.builder()
+                                .name(placeName + i)
+                                .description(placeDescription + i)
+                                .lat(placeLat + i)
+                                .lng(placeLng + i)
+                                .order(i)
+                                .build()
+                );
+            }
+
+            // when, then
+            assertThatThrownBy(
+                    () -> coursePlaceService.batchSaveCoursePlace(invalidCourseId, userId, coursePlaceDtoList)
             ).isInstanceOf(EntityNotFoundException.class);
         }
     }

--- a/course-service/src/test/java/com/comeon/courseservice/web/course/controller/CourseControllerTest.java
+++ b/course-service/src/test/java/com/comeon/courseservice/web/course/controller/CourseControllerTest.java
@@ -2,13 +2,13 @@ package com.comeon.courseservice.web.course.controller;
 
 import com.comeon.courseservice.config.S3MockConfig;
 import com.comeon.courseservice.config.argresolver.JwtArgumentResolver;
+import com.comeon.courseservice.docs.config.RestDocsSupport;
 import com.comeon.courseservice.domain.course.entity.Course;
 import com.comeon.courseservice.domain.course.entity.CourseImage;
 import com.comeon.courseservice.domain.course.entity.CourseWriteStatus;
 import com.comeon.courseservice.domain.course.repository.CourseRepository;
 import com.comeon.courseservice.domain.courseplace.entity.CoursePlace;
 import com.comeon.courseservice.domain.courseplace.repository.CoursePlaceRepository;
-import com.comeon.courseservice.web.common.exception.resolver.CommonControllerAdvice;
 import com.comeon.courseservice.web.common.file.FileManager;
 import com.comeon.courseservice.web.course.response.CourseWritingDoneResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -17,7 +17,6 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.entity.ContentType;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -27,15 +26,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ResourceUtils;
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.filter.CharacterEncodingFilter;
-
-import javax.servlet.ServletException;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -44,6 +39,16 @@ import java.sql.Date;
 import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.snippet.Attributes.attributes;
+import static org.springframework.restdocs.snippet.Attributes.key;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -52,7 +57,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Transactional
 @SpringBootTest
 @Import({S3MockConfig.class})
-class CourseControllerTest {
+class CourseControllerTest extends RestDocsSupport {
 
     @Value("${profile.dirName}")
     String dirName;
@@ -75,8 +80,6 @@ class CourseControllerTest {
     @Autowired
     CourseController courseController;
 
-    MockMvc mockMvc;
-
     Course course;
 
     void initCourse() {
@@ -97,15 +100,6 @@ class CourseControllerTest {
         course = courseRepository.save(courseToSave);
     }
 
-    @BeforeEach
-    void initMockMvc(final WebApplicationContext context) throws ServletException {
-        mockMvc = MockMvcBuilders.standaloneSetup(courseController)
-                .addFilters(new CharacterEncodingFilter("UTF-8", true))
-                .setControllerAdvice(new CommonControllerAdvice())
-                .setCustomArgumentResolvers(jwtArgumentResolver)
-                .build();
-    }
-
     String jwtSecretKey = "8490783c21034fd55f9cde06d539607f326356fa9732d93db12263dc4ce906a02ab20311228a664522bf7ed3ff66f0b3694e94513bdfa17bc631e57030c248ed";
 
     @Nested
@@ -113,16 +107,16 @@ class CourseControllerTest {
     class courseSave {
 
         @Test
-        @DisplayName("요청 데이터 검증에 성공하면, 코스를 저장하고, 해당 코스 식별자를 응답으로 반환한다.")
+        @DisplayName("[docs] 요청 데이터 검증에 성공하면, 코스를 저장하고, 해당 코스 식별자를 응답으로 반환한다.")
         void success() throws Exception {
             // given
             String title = "courseTitle";
             String description = "courseDescription";
 
-            File imgFile = ResourceUtils.getFile(this.getClass().getResource("/static/test-img.jpeg"));
+            File imgFile = ResourceUtils.getFile(this.getClass().getResource("/static/test-img2.png"));
             MockMultipartFile mockMultipartFile = new MockMultipartFile(
                     "imgFile",
-                    "test-img.jpeg",
+                    "test-img2.png",
                     ContentType.IMAGE_JPEG.getMimeType(),
                     new FileInputStream(imgFile)
             );
@@ -150,10 +144,37 @@ class CourseControllerTest {
             // then
             perform.andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.courseId").exists());
+
+            // docs
+            perform.andDo(
+                    document(
+                            "{class-name}/{method-name}",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestHeaders(
+                                    attributes(key("title").value("요청 헤더")),
+                                    headerWithName(HttpHeaders.AUTHORIZATION).description("로그인 및 토큰 재발급을 통해 발급받은 Bearer AccessToken")
+                            ),
+                            requestParts(
+                                    attributes(key("title").value("요청 파트")),
+                                    partWithName("imgFile").description("등록할 이미지 파일")
+                            ),
+                            requestParameters(
+                                    attributes(key("title").value("요청 파라미터")),
+                                    parameterWithName("title").description("코스의 제목"),
+                                    parameterWithName("description").description("코스의 설명")
+                            ),
+                            responseFields(
+                                    beneathPath("data").withSubsectionId("data"),
+                                    attributes(key("title").value("응답 필드")),
+                                    fieldWithPath("courseId").type(JsonFieldType.NUMBER).description("저장된 코스의 식별값")
+                            )
+                    )
+            );
         }
 
         @Test
-        @DisplayName("요청 데이터 검증에 실패하면, http status 400 반환한다.")
+        @DisplayName("[docs] 요청 데이터 검증에 실패하면, http status 400 반환한다.")
         void validationFail() throws Exception {
             Long userId = 1L;
             String userRole = "ROLE_USER";
@@ -177,6 +198,24 @@ class CourseControllerTest {
                     .andExpect(jsonPath("$.data.message.imgFile").exists())
                     .andExpect(jsonPath("$.data.message.description").exists())
                     .andExpect(jsonPath("$.data.message.title").exists());
+
+            // docs
+            perform.andDo(
+                    document(
+                            "{class-name}/{method-name}",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            responseFields(
+                                    beneathPath("data").withSubsectionId("data"),
+                                    attributes(key("title").value("응답 필드")),
+                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("예외 코드"),
+                                    fieldWithPath("message").type(JsonFieldType.OBJECT).description("예외 메시지"),
+                                    fieldWithPath("message.imgFile").ignored(),
+                                    fieldWithPath("message.description").ignored(),
+                                    fieldWithPath("message.title").ignored()
+                            )
+                    )
+            );
         }
     }
 
@@ -213,8 +252,9 @@ class CourseControllerTest {
                     .compact();
 
             // when
+            String path = "/courses/{courseId}/done";
             ResultActions perform = mockMvc.perform(
-                    patch("/courses/{courseId}/done", courseId)
+                    RestDocumentationRequestBuilders.patch(path, courseId)
                             .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
             );
 
@@ -225,6 +265,28 @@ class CourseControllerTest {
             Course findCourse = courseRepository.findById(courseId).orElse(null);
             assertThat(findCourse).isNotNull();
             assertThat(findCourse.getWriteStatus()).isEqualTo(CourseWriteStatus.COMPLETE);
+
+            // docs
+            perform.andDo(
+                    document(
+                            "{class-name}/{method-name}",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestHeaders(
+                                    attributes(key("title").value("요청 헤더")),
+                                    headerWithName(HttpHeaders.AUTHORIZATION).description("로그인 및 토큰 재발급을 통해 발급받은 Bearer AccessToken")
+                            ),
+                            pathParameters(
+                                    attributes(key("title").value(path)),
+                                    parameterWithName("courseId").description("대상 코스 식별값")
+                            ),
+                            responseFields(
+                                    beneathPath("data").withSubsectionId("data"),
+                                    attributes(key("title").value("응답 필드")),
+                                    fieldWithPath("message").type(JsonFieldType.STRING).description("요청 처리 성공 메시지")
+                            )
+                    )
+            );
         }
 
         @Test
@@ -256,7 +318,7 @@ class CourseControllerTest {
         }
 
         @Test
-        @DisplayName("경로 변수로 받은 courseId가 유효하지 않으면, http status 400 반환한다.")
+        @DisplayName("[docs] 경로 변수로 받은 courseId가 유효하지 않으면, http status 400 반환한다.")
         void failEntityNotFound() throws Exception {
             // given
             Long invalidCourseId = 100L;
@@ -280,6 +342,21 @@ class CourseControllerTest {
 
             // then
             perform.andExpect(status().isBadRequest());
+
+            // docs
+            perform.andDo(
+                    document(
+                            "{class-name}/{method-name}",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            responseFields(
+                                    beneathPath("data").withSubsectionId("data"),
+                                    attributes(key("title").value("응답 필드")),
+                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("예외 코드"),
+                                    fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
+                            )
+                    )
+            );
         }
 
         @Test

--- a/course-service/src/test/java/com/comeon/courseservice/web/course/controller/CourseControllerTest.java
+++ b/course-service/src/test/java/com/comeon/courseservice/web/course/controller/CourseControllerTest.java
@@ -1,0 +1,313 @@
+package com.comeon.courseservice.web.course.controller;
+
+import com.comeon.courseservice.config.S3MockConfig;
+import com.comeon.courseservice.config.argresolver.JwtArgumentResolver;
+import com.comeon.courseservice.domain.course.entity.Course;
+import com.comeon.courseservice.domain.course.entity.CourseImage;
+import com.comeon.courseservice.domain.course.entity.CourseWriteStatus;
+import com.comeon.courseservice.domain.course.repository.CourseRepository;
+import com.comeon.courseservice.domain.courseplace.entity.CoursePlace;
+import com.comeon.courseservice.domain.courseplace.repository.CoursePlaceRepository;
+import com.comeon.courseservice.web.common.exception.resolver.CommonControllerAdvice;
+import com.comeon.courseservice.web.common.file.FileManager;
+import com.comeon.courseservice.web.course.response.CourseWritingDoneResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.entity.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.ResourceUtils;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import javax.servlet.ServletException;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.nio.charset.StandardCharsets;
+import java.sql.Date;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Slf4j
+@Transactional
+@SpringBootTest
+@Import({S3MockConfig.class})
+class CourseControllerTest {
+
+    @Value("${profile.dirName}")
+    String dirName;
+
+    @Autowired
+    FileManager fileManager;
+
+    @Autowired
+    CourseRepository courseRepository;
+
+    @Autowired
+    CoursePlaceRepository coursePlaceRepository;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    JwtArgumentResolver jwtArgumentResolver;
+
+    @Autowired
+    CourseController courseController;
+
+    MockMvc mockMvc;
+
+    Course course;
+
+    void initCourse() {
+        Long userId = 1L;
+        String title = "courseTitle";
+        String description = "courseDescription";
+        CourseImage courseImage = CourseImage.builder()
+                .originalName("originalName")
+                .storedName("storedName")
+                .build();
+
+        Course courseToSave = Course.builder()
+                .userId(userId)
+                .title(title)
+                .description(description)
+                .courseImage(courseImage)
+                .build();
+        course = courseRepository.save(courseToSave);
+    }
+
+    @BeforeEach
+    void initMockMvc(final WebApplicationContext context) throws ServletException {
+        mockMvc = MockMvcBuilders.standaloneSetup(courseController)
+                .addFilters(new CharacterEncodingFilter("UTF-8", true))
+                .setControllerAdvice(new CommonControllerAdvice())
+                .setCustomArgumentResolvers(jwtArgumentResolver)
+                .build();
+    }
+
+    String jwtSecretKey = "8490783c21034fd55f9cde06d539607f326356fa9732d93db12263dc4ce906a02ab20311228a664522bf7ed3ff66f0b3694e94513bdfa17bc631e57030c248ed";
+
+    @Nested
+    @DisplayName("코스 저장")
+    class courseSave {
+
+        @Test
+        @DisplayName("요청 데이터 검증에 성공하면, 코스를 저장하고, 해당 코스 식별자를 응답으로 반환한다.")
+        void success() throws Exception {
+            // given
+            String title = "courseTitle";
+            String description = "courseDescription";
+
+            File imgFile = ResourceUtils.getFile(this.getClass().getResource("/static/test-img.jpeg"));
+            MockMultipartFile mockMultipartFile = new MockMultipartFile(
+                    "imgFile",
+                    "test-img.jpeg",
+                    ContentType.IMAGE_JPEG.getMimeType(),
+                    new FileInputStream(imgFile)
+            );
+
+            Long userId = 1L;
+            String userRole = "ROLE_USER";
+            String accessToken = Jwts.builder()
+                    .signWith(Keys.hmacShaKeyFor(jwtSecretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS512)
+                    .claim("auth", userRole)
+                    .setIssuer("test")
+                    .setIssuedAt(Date.from(Instant.now()))
+                    .setExpiration(Date.from(Instant.now().plusSeconds(100)))
+                    .setSubject(userId.toString())
+                    .compact();
+
+            // when
+            ResultActions perform = mockMvc.perform(
+                    multipart("/courses")
+                            .file(mockMultipartFile)
+                            .param("title", title)
+                            .param("description", description)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+            );
+
+            // then
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.courseId").exists());
+        }
+
+        @Test
+        @DisplayName("요청 데이터 검증에 실패하면, http status 400 반환한다.")
+        void validationFail() throws Exception {
+            Long userId = 1L;
+            String userRole = "ROLE_USER";
+            String accessToken = Jwts.builder()
+                    .signWith(Keys.hmacShaKeyFor(jwtSecretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS512)
+                    .claim("auth", userRole)
+                    .setIssuer("test")
+                    .setIssuedAt(Date.from(Instant.now()))
+                    .setExpiration(Date.from(Instant.now().plusSeconds(100)))
+                    .setSubject(userId.toString())
+                    .compact();
+
+            // when
+            ResultActions perform = mockMvc.perform(
+                    multipart("/courses")
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+            );
+
+            // then
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.data.message.imgFile").exists())
+                    .andExpect(jsonPath("$.data.message.description").exists())
+                    .andExpect(jsonPath("$.data.message.title").exists());
+        }
+    }
+
+    @Nested
+    @DisplayName("코스 작성 완료 처리")
+    class courseWritingDone {
+
+        @Test
+        @DisplayName("코스에 장소가 등록되어 있다면, 해당 코스의 작성 상태를 변경하고, 요청 처리 완료 메시지를 응답한다.")
+        void success() throws Exception {
+            // given
+            initCourse();
+            Long courseId = course.getId();
+
+            CoursePlace coursePlace = CoursePlace.builder()
+                    .course(course)
+                    .name("placeName")
+                    .description("placeDescription")
+                    .lat(12.34)
+                    .lng(34.56)
+                    .order(1)
+                    .build();
+            coursePlaceRepository.save(coursePlace);
+
+            Long userId = course.getUserId();
+            String userRole = "ROLE_USER";
+            String accessToken = Jwts.builder()
+                    .signWith(Keys.hmacShaKeyFor(jwtSecretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS512)
+                    .claim("auth", userRole)
+                    .setIssuer("test")
+                    .setIssuedAt(Date.from(Instant.now()))
+                    .setExpiration(Date.from(Instant.now().plusSeconds(100)))
+                    .setSubject(userId.toString())
+                    .compact();
+
+            // when
+            ResultActions perform = mockMvc.perform(
+                    patch("/courses/{courseId}/done", courseId)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+            );
+
+            // then
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.message").value(CourseWritingDoneResponse.SUCCESS_MESSAGE));
+
+            Course findCourse = courseRepository.findById(courseId).orElse(null);
+            assertThat(findCourse).isNotNull();
+            assertThat(findCourse.getWriteStatus()).isEqualTo(CourseWriteStatus.COMPLETE);
+        }
+
+        @Test
+        @DisplayName("코스에 장소가 등록되어있지 않으면, 요청이 실패하고 http status 400 반환한다.")
+        void failNoPlaces() throws Exception {
+            // given
+            initCourse();
+            Long courseId = course.getId();
+
+            Long userId = course.getUserId();
+            String userRole = "ROLE_USER";
+            String accessToken = Jwts.builder()
+                    .signWith(Keys.hmacShaKeyFor(jwtSecretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS512)
+                    .claim("auth", userRole)
+                    .setIssuer("test")
+                    .setIssuedAt(Date.from(Instant.now()))
+                    .setExpiration(Date.from(Instant.now().plusSeconds(100)))
+                    .setSubject(userId.toString())
+                    .compact();
+
+            // when
+            ResultActions perform = mockMvc.perform(
+                    patch("/courses/{courseId}/done", courseId)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+            );
+
+            // then
+            perform.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("경로 변수로 받은 courseId가 유효하지 않으면, http status 400 반환한다.")
+        void failEntityNotFound() throws Exception {
+            // given
+            Long invalidCourseId = 100L;
+
+            Long userId = 1L;
+            String userRole = "ROLE_USER";
+            String accessToken = Jwts.builder()
+                    .signWith(Keys.hmacShaKeyFor(jwtSecretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS512)
+                    .claim("auth", userRole)
+                    .setIssuer("test")
+                    .setIssuedAt(Date.from(Instant.now()))
+                    .setExpiration(Date.from(Instant.now().plusSeconds(100)))
+                    .setSubject(userId.toString())
+                    .compact();
+
+            // when
+            ResultActions perform = mockMvc.perform(
+                    patch("/courses/{courseId}/done", invalidCourseId)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+            );
+
+            // then
+            perform.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("코스를 등록한 유저와 상태 변경 요청한 유저의 식별자가 다르면, http status 403 반환한다.")
+        void failNoAuthorities() throws Exception {
+            // given
+            initCourse();
+            Long courseId = course.getId();
+
+            Long invalidUserId = 100L;
+            String userRole = "ROLE_USER";
+            String accessToken = Jwts.builder()
+                    .signWith(Keys.hmacShaKeyFor(jwtSecretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS512)
+                    .claim("auth", userRole)
+                    .setIssuer("test")
+                    .setIssuedAt(Date.from(Instant.now()))
+                    .setExpiration(Date.from(Instant.now().plusSeconds(100)))
+                    .setSubject(invalidUserId.toString())
+                    .compact();
+
+            // when
+            ResultActions perform = mockMvc.perform(
+                    patch("/courses/{courseId}/done", courseId)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+            );
+
+            // then
+            perform.andExpect(status().isForbidden());
+        }
+    }
+}

--- a/course-service/src/test/java/com/comeon/courseservice/web/course/controller/CourseControllerTest.java
+++ b/course-service/src/test/java/com/comeon/courseservice/web/course/controller/CourseControllerTest.java
@@ -5,12 +5,9 @@ import com.comeon.courseservice.config.argresolver.JwtArgumentResolver;
 import com.comeon.courseservice.docs.config.RestDocsSupport;
 import com.comeon.courseservice.domain.course.entity.Course;
 import com.comeon.courseservice.domain.course.entity.CourseImage;
-import com.comeon.courseservice.domain.course.entity.CourseWriteStatus;
 import com.comeon.courseservice.domain.course.repository.CourseRepository;
-import com.comeon.courseservice.domain.courseplace.entity.CoursePlace;
 import com.comeon.courseservice.domain.courseplace.repository.CoursePlaceRepository;
 import com.comeon.courseservice.web.common.file.FileManager;
-import com.comeon.courseservice.web.course.response.CourseWritingDoneResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -26,7 +23,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
@@ -59,7 +55,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import({S3MockConfig.class})
 class CourseControllerTest extends RestDocsSupport {
 
-    @Value("${profile.dirName}")
+    @Value("${s3.folder-name.course}")
     String dirName;
 
     @Autowired
@@ -219,172 +215,4 @@ class CourseControllerTest extends RestDocsSupport {
         }
     }
 
-    @Nested
-    @DisplayName("코스 작성 완료 처리")
-    class courseWritingDone {
-
-        @Test
-        @DisplayName("코스에 장소가 등록되어 있다면, 해당 코스의 작성 상태를 변경하고, 요청 처리 완료 메시지를 응답한다.")
-        void success() throws Exception {
-            // given
-            initCourse();
-            Long courseId = course.getId();
-
-            CoursePlace coursePlace = CoursePlace.builder()
-                    .course(course)
-                    .name("placeName")
-                    .description("placeDescription")
-                    .lat(12.34)
-                    .lng(34.56)
-                    .order(1)
-                    .build();
-            coursePlaceRepository.save(coursePlace);
-
-            Long userId = course.getUserId();
-            String userRole = "ROLE_USER";
-            String accessToken = Jwts.builder()
-                    .signWith(Keys.hmacShaKeyFor(jwtSecretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS512)
-                    .claim("auth", userRole)
-                    .setIssuer("test")
-                    .setIssuedAt(Date.from(Instant.now()))
-                    .setExpiration(Date.from(Instant.now().plusSeconds(100)))
-                    .setSubject(userId.toString())
-                    .compact();
-
-            // when
-            String path = "/courses/{courseId}/done";
-            ResultActions perform = mockMvc.perform(
-                    RestDocumentationRequestBuilders.patch(path, courseId)
-                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
-            );
-
-            // then
-            perform.andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data.message").value(CourseWritingDoneResponse.SUCCESS_MESSAGE));
-
-            Course findCourse = courseRepository.findById(courseId).orElse(null);
-            assertThat(findCourse).isNotNull();
-            assertThat(findCourse.getWriteStatus()).isEqualTo(CourseWriteStatus.COMPLETE);
-
-            // docs
-            perform.andDo(
-                    document(
-                            "{class-name}/{method-name}",
-                            preprocessRequest(prettyPrint()),
-                            preprocessResponse(prettyPrint()),
-                            requestHeaders(
-                                    attributes(key("title").value("요청 헤더")),
-                                    headerWithName(HttpHeaders.AUTHORIZATION).description("로그인 및 토큰 재발급을 통해 발급받은 Bearer AccessToken")
-                            ),
-                            pathParameters(
-                                    attributes(key("title").value(path)),
-                                    parameterWithName("courseId").description("대상 코스 식별값")
-                            ),
-                            responseFields(
-                                    beneathPath("data").withSubsectionId("data"),
-                                    attributes(key("title").value("응답 필드")),
-                                    fieldWithPath("message").type(JsonFieldType.STRING).description("요청 처리 성공 메시지")
-                            )
-                    )
-            );
-        }
-
-        @Test
-        @DisplayName("코스에 장소가 등록되어있지 않으면, 요청이 실패하고 http status 400 반환한다.")
-        void failNoPlaces() throws Exception {
-            // given
-            initCourse();
-            Long courseId = course.getId();
-
-            Long userId = course.getUserId();
-            String userRole = "ROLE_USER";
-            String accessToken = Jwts.builder()
-                    .signWith(Keys.hmacShaKeyFor(jwtSecretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS512)
-                    .claim("auth", userRole)
-                    .setIssuer("test")
-                    .setIssuedAt(Date.from(Instant.now()))
-                    .setExpiration(Date.from(Instant.now().plusSeconds(100)))
-                    .setSubject(userId.toString())
-                    .compact();
-
-            // when
-            ResultActions perform = mockMvc.perform(
-                    patch("/courses/{courseId}/done", courseId)
-                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
-            );
-
-            // then
-            perform.andExpect(status().isBadRequest());
-        }
-
-        @Test
-        @DisplayName("[docs] 경로 변수로 받은 courseId가 유효하지 않으면, http status 400 반환한다.")
-        void failEntityNotFound() throws Exception {
-            // given
-            Long invalidCourseId = 100L;
-
-            Long userId = 1L;
-            String userRole = "ROLE_USER";
-            String accessToken = Jwts.builder()
-                    .signWith(Keys.hmacShaKeyFor(jwtSecretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS512)
-                    .claim("auth", userRole)
-                    .setIssuer("test")
-                    .setIssuedAt(Date.from(Instant.now()))
-                    .setExpiration(Date.from(Instant.now().plusSeconds(100)))
-                    .setSubject(userId.toString())
-                    .compact();
-
-            // when
-            ResultActions perform = mockMvc.perform(
-                    patch("/courses/{courseId}/done", invalidCourseId)
-                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
-            );
-
-            // then
-            perform.andExpect(status().isBadRequest());
-
-            // docs
-            perform.andDo(
-                    document(
-                            "{class-name}/{method-name}",
-                            preprocessRequest(prettyPrint()),
-                            preprocessResponse(prettyPrint()),
-                            responseFields(
-                                    beneathPath("data").withSubsectionId("data"),
-                                    attributes(key("title").value("응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("예외 코드"),
-                                    fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
-                            )
-                    )
-            );
-        }
-
-        @Test
-        @DisplayName("코스를 등록한 유저와 상태 변경 요청한 유저의 식별자가 다르면, http status 403 반환한다.")
-        void failNoAuthorities() throws Exception {
-            // given
-            initCourse();
-            Long courseId = course.getId();
-
-            Long invalidUserId = 100L;
-            String userRole = "ROLE_USER";
-            String accessToken = Jwts.builder()
-                    .signWith(Keys.hmacShaKeyFor(jwtSecretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS512)
-                    .claim("auth", userRole)
-                    .setIssuer("test")
-                    .setIssuedAt(Date.from(Instant.now()))
-                    .setExpiration(Date.from(Instant.now().plusSeconds(100)))
-                    .setSubject(invalidUserId.toString())
-                    .compact();
-
-            // when
-            ResultActions perform = mockMvc.perform(
-                    patch("/courses/{courseId}/done", courseId)
-                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
-            );
-
-            // then
-            perform.andExpect(status().isForbidden());
-        }
-    }
 }

--- a/course-service/src/test/java/com/comeon/courseservice/web/courseplace/controller/CoursePlaceControllerTest.java
+++ b/course-service/src/test/java/com/comeon/courseservice/web/courseplace/controller/CoursePlaceControllerTest.java
@@ -1,0 +1,247 @@
+package com.comeon.courseservice.web.courseplace.controller;
+
+import com.comeon.courseservice.config.argresolver.JwtArgumentResolver;
+import com.comeon.courseservice.domain.course.entity.Course;
+import com.comeon.courseservice.domain.course.entity.CourseImage;
+import com.comeon.courseservice.domain.course.repository.CourseRepository;
+import com.comeon.courseservice.domain.courseplace.repository.CoursePlaceRepository;
+import com.comeon.courseservice.web.common.exception.resolver.CommonControllerAdvice;
+import com.comeon.courseservice.web.courseplace.request.CoursePlaceSaveRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import javax.servlet.ServletException;
+
+import java.nio.charset.StandardCharsets;
+import java.sql.Date;
+import java.time.Instant;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Slf4j
+@Transactional
+@SpringBootTest
+class CoursePlaceControllerTest {
+
+    @Autowired
+    CourseRepository courseRepository;
+
+    @Autowired
+    CoursePlaceRepository coursePlaceRepository;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    JwtArgumentResolver jwtArgumentResolver;
+
+    @Autowired
+    CoursePlaceController coursePlaceController;
+
+    MockMvc mockMvc;
+
+    Course course;
+
+    void initCourse() {
+        Long userId = 1L;
+        String title = "courseTitle";
+        String description = "courseDescription";
+        CourseImage courseImage = CourseImage.builder()
+                .originalName("originalName")
+                .storedName("storedName")
+                .build();
+
+        Course courseToSave = Course.builder()
+                .userId(userId)
+                .title(title)
+                .description(description)
+                .courseImage(courseImage)
+                .build();
+        course = courseRepository.save(courseToSave);
+    }
+
+    @BeforeEach
+    void initMockMvc(final WebApplicationContext context) throws ServletException {
+        mockMvc = MockMvcBuilders.standaloneSetup(coursePlaceController)
+                .addFilters(new CharacterEncodingFilter("UTF-8", true))
+                .setControllerAdvice(new CommonControllerAdvice())
+                .setCustomArgumentResolvers(jwtArgumentResolver)
+                .build();
+    }
+
+    String jwtSecretKey = "8490783c21034fd55f9cde06d539607f326356fa9732d93db12263dc4ce906a02ab20311228a664522bf7ed3ff66f0b3694e94513bdfa17bc631e57030c248ed";
+
+    @Nested
+    @DisplayName("코스 장소 등록")
+    class coursePlaceSave {
+
+        @Test
+        @DisplayName("요청 데이터 검증에 성공하면, 해당 코스에 장소를 저장한다.")
+        void success() throws Exception {
+            // given
+            initCourse();
+            Long courseId = course.getId();
+            String name = "placeName";
+            String description = "placeDescription";
+            Double lat = 12.34;
+            Double lng = 34.56;
+
+            CoursePlaceSaveRequest request = new CoursePlaceSaveRequest(courseId, name, description, lat, lng);
+
+            Long userId = course.getUserId();
+            String userRole = "ROLE_USER";
+            String accessToken = Jwts.builder()
+                    .signWith(Keys.hmacShaKeyFor(jwtSecretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS512)
+                    .claim("auth", userRole)
+                    .setIssuer("test")
+                    .setIssuedAt(Date.from(Instant.now()))
+                    .setExpiration(Date.from(Instant.now().plusSeconds(100)))
+                    .setSubject(userId.toString())
+                    .compact();
+
+            // when
+            ResultActions perform = mockMvc.perform(
+                    post("/course-places")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                            .content(objectMapper.writeValueAsString(request))
+            );
+
+            // then
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.coursePlaceId").exists());
+        }
+
+        @Test
+        @DisplayName("요청 데이터 검증에 실패하면, http status 400 반환하고, 검증 오류 필드가 담긴다.")
+        void fail() throws Exception {
+            // given
+            initCourse();
+
+            CoursePlaceSaveRequest request = new CoursePlaceSaveRequest();
+
+            Long userId = course.getUserId();
+            String userRole = "ROLE_USER";
+            String accessToken = Jwts.builder()
+                    .signWith(Keys.hmacShaKeyFor(jwtSecretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS512)
+                    .claim("auth", userRole)
+                    .setIssuer("test")
+                    .setIssuedAt(Date.from(Instant.now()))
+                    .setExpiration(Date.from(Instant.now().plusSeconds(100)))
+                    .setSubject(userId.toString())
+                    .compact();
+
+            // when
+            ResultActions perform = mockMvc.perform(
+                    post("/course-places")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                            .content(objectMapper.writeValueAsString(request))
+            );
+
+            log.info("result : {}", perform.andReturn().getResponse().getContentAsString());
+            // then
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.data.message.courseId").exists())
+                    .andExpect(jsonPath("$.data.message.name").exists())
+                    .andExpect(jsonPath("$.data.message.description").exists())
+                    .andExpect(jsonPath("$.data.message.lat").exists())
+                    .andExpect(jsonPath("$.data.message.lng").exists());
+        }
+
+        @Test
+        @DisplayName("요청 데이터 검증에는 성공했으나, 저장되지 않은 코스의 식별자가 넘어오면, http status 400 반환한다.")
+        void fail2() throws Exception {
+            // given
+            initCourse();
+            Long courseId = 100L;
+            String name = "placeName";
+            String description = "placeDescription";
+            Double lat = 12.34;
+            Double lng = 34.56;
+
+            CoursePlaceSaveRequest request = new CoursePlaceSaveRequest(courseId, name, description, lat, lng);
+
+            Long userId = course.getUserId();
+            String userRole = "ROLE_USER";
+            String accessToken = Jwts.builder()
+                    .signWith(Keys.hmacShaKeyFor(jwtSecretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS512)
+                    .claim("auth", userRole)
+                    .setIssuer("test")
+                    .setIssuedAt(Date.from(Instant.now()))
+                    .setExpiration(Date.from(Instant.now().plusSeconds(100)))
+                    .setSubject(userId.toString())
+                    .compact();
+
+            // when
+            ResultActions perform = mockMvc.perform(
+                    post("/course-places")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                            .content(objectMapper.writeValueAsString(request))
+            );
+
+            // then
+            perform.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("요청 데이터 검증에는 성공했으나, 코스를 등록한 유저가 아니면, http status 403 반환한다.")
+        void fail3() throws Exception {
+            // given
+            initCourse();
+            Long courseId = course.getId();
+            String name = "placeName";
+            String description = "placeDescription";
+            Double lat = 12.34;
+            Double lng = 34.56;
+
+            CoursePlaceSaveRequest request = new CoursePlaceSaveRequest(courseId, name, description, lat, lng);
+
+            Long invalidUserId = 100L;
+            String userRole = "ROLE_USER";
+            String accessToken = Jwts.builder()
+                    .signWith(Keys.hmacShaKeyFor(jwtSecretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS512)
+                    .claim("auth", userRole)
+                    .setIssuer("test")
+                    .setIssuedAt(Date.from(Instant.now()))
+                    .setExpiration(Date.from(Instant.now().plusSeconds(100)))
+                    .setSubject(invalidUserId.toString())
+                    .compact();
+
+            // when
+            ResultActions perform = mockMvc.perform(
+                    post("/course-places")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                            .content(objectMapper.writeValueAsString(request))
+            );
+
+            // then
+            perform.andExpect(status().isForbidden());
+        }
+    }
+}

--- a/course-service/src/test/java/com/comeon/courseservice/web/courseplace/controller/CoursePlaceControllerTest.java
+++ b/course-service/src/test/java/com/comeon/courseservice/web/courseplace/controller/CoursePlaceControllerTest.java
@@ -1,18 +1,17 @@
 package com.comeon.courseservice.web.courseplace.controller;
 
 import com.comeon.courseservice.config.argresolver.JwtArgumentResolver;
+import com.comeon.courseservice.docs.config.RestDocsSupport;
 import com.comeon.courseservice.domain.course.entity.Course;
 import com.comeon.courseservice.domain.course.entity.CourseImage;
 import com.comeon.courseservice.domain.course.repository.CourseRepository;
 import com.comeon.courseservice.domain.courseplace.repository.CoursePlaceRepository;
-import com.comeon.courseservice.web.common.exception.resolver.CommonControllerAdvice;
 import com.comeon.courseservice.web.courseplace.request.CoursePlaceSaveRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -20,19 +19,25 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.filter.CharacterEncodingFilter;
-
-import javax.servlet.ServletException;
 
 import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.time.Instant;
 
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
+import static org.springframework.restdocs.snippet.Attributes.attributes;
+import static org.springframework.restdocs.snippet.Attributes.key;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -40,7 +45,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Slf4j
 @Transactional
 @SpringBootTest
-class CoursePlaceControllerTest {
+class CoursePlaceControllerTest extends RestDocsSupport {
 
     @Autowired
     CourseRepository courseRepository;
@@ -56,8 +61,6 @@ class CoursePlaceControllerTest {
 
     @Autowired
     CoursePlaceController coursePlaceController;
-
-    MockMvc mockMvc;
 
     Course course;
 
@@ -79,15 +82,6 @@ class CoursePlaceControllerTest {
         course = courseRepository.save(courseToSave);
     }
 
-    @BeforeEach
-    void initMockMvc(final WebApplicationContext context) throws ServletException {
-        mockMvc = MockMvcBuilders.standaloneSetup(coursePlaceController)
-                .addFilters(new CharacterEncodingFilter("UTF-8", true))
-                .setControllerAdvice(new CommonControllerAdvice())
-                .setCustomArgumentResolvers(jwtArgumentResolver)
-                .build();
-    }
-
     String jwtSecretKey = "8490783c21034fd55f9cde06d539607f326356fa9732d93db12263dc4ce906a02ab20311228a664522bf7ed3ff66f0b3694e94513bdfa17bc631e57030c248ed";
 
     @Nested
@@ -95,7 +89,7 @@ class CoursePlaceControllerTest {
     class coursePlaceSave {
 
         @Test
-        @DisplayName("요청 데이터 검증에 성공하면, 해당 코스에 장소를 저장한다.")
+        @DisplayName("[docs] 요청 데이터 검증에 성공하면, 해당 코스에 장소를 저장한다.")
         void success() throws Exception {
             // given
             initCourse();
@@ -130,10 +124,36 @@ class CoursePlaceControllerTest {
             // then
             perform.andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.coursePlaceId").exists());
+
+            // docs
+            perform.andDo(
+                    document(
+                            "{class-name}/{method-name}",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestHeaders(
+                                    attributes(key("title").value("요청 헤더")),
+                                    headerWithName(HttpHeaders.AUTHORIZATION).description("로그인 및 토큰 재발급을 통해 발급받은 Bearer AccessToken")
+                            ),
+                            requestFields(
+                                    attributes(key("title").value("요청 필드")),
+                                    fieldWithPath("courseId").type(JsonFieldType.NUMBER).description("대상 코스의 식별값"),
+                                    fieldWithPath("name").type(JsonFieldType.STRING).description("장소 이름"),
+                                    fieldWithPath("description").type(JsonFieldType.STRING).description("장소의 설명"),
+                                    fieldWithPath("lat").type(JsonFieldType.NUMBER).description("장소의 위도값"),
+                                    fieldWithPath("lng").type(JsonFieldType.NUMBER).description("장소의 경도값")
+                            ),
+                            responseFields(
+                                    beneathPath("data").withSubsectionId("data"),
+                                    attributes(key("title").value("응답 필드")),
+                                    fieldWithPath("coursePlaceId").type(JsonFieldType.NUMBER).description("저장된 코스 장소 식별값")
+                            )
+                    )
+            );
         }
 
         @Test
-        @DisplayName("요청 데이터 검증에 실패하면, http status 400 반환하고, 검증 오류 필드가 담긴다.")
+        @DisplayName("[docs] 요청 데이터 검증에 실패하면, http status 400 반환하고, 검증 오류 필드가 담긴다.")
         void fail() throws Exception {
             // given
             initCourse();
@@ -168,6 +188,26 @@ class CoursePlaceControllerTest {
                     .andExpect(jsonPath("$.data.message.description").exists())
                     .andExpect(jsonPath("$.data.message.lat").exists())
                     .andExpect(jsonPath("$.data.message.lng").exists());
+
+            // docs
+            perform.andDo(
+                    document(
+                            "{class-name}/{method-name}",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            responseFields(
+                                    beneathPath("data").withSubsectionId("data"),
+                                    attributes(key("title").value("응답 필드")),
+                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("예외 코드"),
+                                    fieldWithPath("message").type(JsonFieldType.OBJECT).description("예외 메시지"),
+                                    fieldWithPath("message.courseId").ignored(),
+                                    fieldWithPath("message.name").ignored(),
+                                    fieldWithPath("message.description").ignored(),
+                                    fieldWithPath("message.lat").ignored(),
+                                    fieldWithPath("message.lng").ignored()
+                            )
+                    )
+            );
         }
 
         @Test

--- a/course-service/src/test/java/com/comeon/courseservice/web/courseplace/controller/CoursePlaceControllerTest.java
+++ b/course-service/src/test/java/com/comeon/courseservice/web/courseplace/controller/CoursePlaceControllerTest.java
@@ -7,6 +7,7 @@ import com.comeon.courseservice.domain.course.entity.CourseImage;
 import com.comeon.courseservice.domain.course.repository.CourseRepository;
 import com.comeon.courseservice.domain.courseplace.repository.CoursePlaceRepository;
 import com.comeon.courseservice.web.courseplace.request.CoursePlaceSaveRequest;
+import com.comeon.courseservice.web.courseplace.request.CoursePlacesBatchSaveRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -26,6 +27,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
@@ -34,8 +37,6 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
 import static org.springframework.restdocs.snippet.Attributes.attributes;
 import static org.springframework.restdocs.snippet.Attributes.key;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -282,6 +283,305 @@ class CoursePlaceControllerTest extends RestDocsSupport {
 
             // then
             perform.andExpect(status().isForbidden());
+        }
+    }
+
+    @Nested
+    @DisplayName("코스 장소 리스트 등록")
+    class coursePlaceSaveBatch {
+        @Test
+        @DisplayName("[docs] 요청 데이터 검증에 성공하면, 해당 코스에 장소 리스트를 저장한다.")
+        void success() throws Exception {
+            // given
+            initCourse();
+            Long courseId = course.getId();
+
+            int count = 5;
+            String placeName = "placeName";
+            String placeDescription = "placeDescription";
+            Double placeLat = 12.34;
+            Double placeLng = 34.56;
+            List<CoursePlacesBatchSaveRequest.CoursePlaceInfo> coursePlaceInfoList = new ArrayList<>();
+            for (int i = 1; i <= count; i++) {
+                coursePlaceInfoList.add(
+                        CoursePlacesBatchSaveRequest.CoursePlaceInfo.builder()
+                                .name(placeName + i)
+                                .description(placeDescription + i)
+                                .lat(placeLat + i)
+                                .lng(placeLng + i)
+                                .order(i)
+                                .build()
+                );
+            }
+
+            CoursePlacesBatchSaveRequest request = new CoursePlacesBatchSaveRequest(courseId, coursePlaceInfoList);
+
+            Long userId = course.getUserId();
+            String userRole = "ROLE_USER";
+            String accessToken = Jwts.builder()
+                    .signWith(Keys.hmacShaKeyFor(jwtSecretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS512)
+                    .claim("auth", userRole)
+                    .setIssuer("test")
+                    .setIssuedAt(Date.from(Instant.now()))
+                    .setExpiration(Date.from(Instant.now().plusSeconds(100)))
+                    .setSubject(userId.toString())
+                    .compact();
+
+            // when
+            ResultActions perform = mockMvc.perform(
+                    post("/course-places/batch")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                            .content(objectMapper.writeValueAsString(request))
+            );
+
+            // then
+            perform.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.message").exists());
+
+            // docs
+            perform.andDo(
+                    document(
+                            "{class-name}/{method-name}",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestHeaders(
+                                    attributes(key("title").value("요청 헤더")),
+                                    headerWithName(HttpHeaders.AUTHORIZATION).description("로그인 및 토큰 재발급을 통해 발급받은 Bearer AccessToken")
+                            ),
+                            requestFields(
+                                    attributes(key("title").value("요청 필드")),
+                                    fieldWithPath("courseId").type(JsonFieldType.NUMBER).description("대상 코스의 식별값"),
+                                    fieldWithPath("coursePlaces").type(JsonFieldType.ARRAY).description("대상 코스에 등록할 장소 리스트"),
+                                    fieldWithPath("coursePlaces[].name").type(JsonFieldType.STRING).description("장소 이름"),
+                                    fieldWithPath("coursePlaces[].description").type(JsonFieldType.STRING).description("장소의 설명"),
+                                    fieldWithPath("coursePlaces[].lat").type(JsonFieldType.NUMBER).description("장소의 위도값"),
+                                    fieldWithPath("coursePlaces[].lng").type(JsonFieldType.NUMBER).description("장소의 경도값"),
+                                    fieldWithPath("coursePlaces[].order").type(JsonFieldType.NUMBER).description("장소의 순서")
+                            ),
+                            responseFields(
+                                    beneathPath("data").withSubsectionId("data"),
+                                    attributes(key("title").value("응답 필드")),
+                                    fieldWithPath("message").type(JsonFieldType.STRING).description("장소 리스트 저장 성공 메시지")
+                            )
+                    )
+            );
+        }
+
+        @Test
+        @DisplayName("[docs] 장소 리스트에서 특정 장소의 특정 필수값이 빠진 경우, 요청 데이터 검증에 실패하고 http status 400 반환, 응답에는 검증 오류 필드가 담긴다.")
+        void failSpecificField() throws Exception {
+            // given
+            initCourse();
+            Long courseId = course.getId();
+
+            int count = 5;
+            String placeName = "placeName";
+            String placeDescription = "placeDescription";
+            Double placeLat = 12.34;
+            Double placeLng = 34.56;
+            List<CoursePlacesBatchSaveRequest.CoursePlaceInfo> coursePlaceInfoList = new ArrayList<>();
+            for (int i = 1; i <= count; i++) {
+                coursePlaceInfoList.add(
+                        CoursePlacesBatchSaveRequest.CoursePlaceInfo.builder()
+                                .name(placeName + i)
+                                .description(placeDescription + i)
+                                // i가 홀수이면 lat 정보를 넣지 않는다. -> 검증 실패
+                                .lat(i % 2 == 0 ? placeLat + i : null)
+                                .lng(placeLng + i)
+                                .order(i % 2 != 0 ? i : null)
+                                .build()
+                );
+            }
+
+            CoursePlacesBatchSaveRequest request = new CoursePlacesBatchSaveRequest(courseId, coursePlaceInfoList);
+
+            Long userId = course.getUserId();
+            String userRole = "ROLE_USER";
+            String accessToken = Jwts.builder()
+                    .signWith(Keys.hmacShaKeyFor(jwtSecretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS512)
+                    .claim("auth", userRole)
+                    .setIssuer("test")
+                    .setIssuedAt(Date.from(Instant.now()))
+                    .setExpiration(Date.from(Instant.now().plusSeconds(100)))
+                    .setSubject(userId.toString())
+                    .compact();
+
+            // when
+            ResultActions perform = mockMvc.perform(
+                    post("/course-places/batch")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                            .content(objectMapper.writeValueAsString(request))
+            );
+
+            log.info("result : {}", perform.andReturn().getResponse().getContentAsString());
+            // then
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.data.message").exists());
+
+            // docs
+            perform.andDo(
+                    document(
+                            "{class-name}/{method-name}",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint())
+                    )
+            );
+        }
+
+        @Test
+        @DisplayName("[docs] 장소 리스트가 없는 경우, 요청 데이터 검증에 실패하고 http status 400 반환, 응답에는 검증 오류 필드가 담긴다.")
+        void failAllField() throws Exception {
+            // given
+            initCourse();
+            Long courseId = course.getId();
+
+            CoursePlacesBatchSaveRequest request = new CoursePlacesBatchSaveRequest(courseId, null);
+
+            Long userId = course.getUserId();
+            String userRole = "ROLE_USER";
+            String accessToken = Jwts.builder()
+                    .signWith(Keys.hmacShaKeyFor(jwtSecretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS512)
+                    .claim("auth", userRole)
+                    .setIssuer("test")
+                    .setIssuedAt(Date.from(Instant.now()))
+                    .setExpiration(Date.from(Instant.now().plusSeconds(100)))
+                    .setSubject(userId.toString())
+                    .compact();
+
+            // when
+            ResultActions perform = mockMvc.perform(
+                    post("/course-places/batch")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                            .content(objectMapper.writeValueAsString(request))
+            );
+
+            log.info("result : {}", perform.andReturn().getResponse().getContentAsString());
+            // then
+            perform.andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.data.message").exists());
+
+            // docs
+            perform.andDo(
+                    document(
+                            "{class-name}/{method-name}",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            responseFields(
+                                    beneathPath("data").withSubsectionId("data"),
+                                    attributes(key("title").value("응답 필드")),
+                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("예외 코드"),
+                                    fieldWithPath("message").type(JsonFieldType.OBJECT).description("예외 메시지"),
+                                    fieldWithPath("message.coursePlaces").ignored()
+                            )
+                    )
+            );
+        }
+
+        @Test
+        @DisplayName("요청 데이터 검증에는 성공했으나, 코스를 등록한 유저가 아니면, http status 403 반환한다.")
+        void failInvalidUser() throws Exception {
+            // given
+            initCourse();
+            Long courseId = course.getId();
+
+            int count = 5;
+            String placeName = "placeName";
+            String placeDescription = "placeDescription";
+            Double placeLat = 12.34;
+            Double placeLng = 34.56;
+            List<CoursePlacesBatchSaveRequest.CoursePlaceInfo> coursePlaceInfoList = new ArrayList<>();
+            for (int i = 1; i <= count; i++) {
+                coursePlaceInfoList.add(
+                        CoursePlacesBatchSaveRequest.CoursePlaceInfo.builder()
+                                .name(placeName + i)
+                                .description(placeDescription + i)
+                                .lat(placeLat + i)
+                                .lng(placeLng + i)
+                                .order(i)
+                                .build()
+                );
+            }
+
+            CoursePlacesBatchSaveRequest request = new CoursePlacesBatchSaveRequest(courseId, coursePlaceInfoList);
+
+            Long invalidUserId = 100L;
+            String userRole = "ROLE_USER";
+            String accessToken = Jwts.builder()
+                    .signWith(Keys.hmacShaKeyFor(jwtSecretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS512)
+                    .claim("auth", userRole)
+                    .setIssuer("test")
+                    .setIssuedAt(Date.from(Instant.now()))
+                    .setExpiration(Date.from(Instant.now().plusSeconds(100)))
+                    .setSubject(invalidUserId.toString())
+                    .compact();
+
+            // when
+            ResultActions perform = mockMvc.perform(
+                    post("/course-places/batch")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                            .content(objectMapper.writeValueAsString(request))
+            );
+
+            // then
+            perform.andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("요청 데이터 검증에는 성공했으나, 저장되지 않은 코스의 식별자가 넘어오면, http status 400 반환한다.")
+        void failInvalidCourse() throws Exception {
+            // given
+            initCourse();
+            Long courseId = 100L;
+            int count = 5;
+            String placeName = "placeName";
+            String placeDescription = "placeDescription";
+            Double placeLat = 12.34;
+            Double placeLng = 34.56;
+            List<CoursePlacesBatchSaveRequest.CoursePlaceInfo> coursePlaceInfoList = new ArrayList<>();
+            for (int i = 1; i <= count; i++) {
+                coursePlaceInfoList.add(
+                        CoursePlacesBatchSaveRequest.CoursePlaceInfo.builder()
+                                .name(placeName + i)
+                                .description(placeDescription + i)
+                                .lat(placeLat + i)
+                                .lng(placeLng + i)
+                                .order(i)
+                                .build()
+                );
+            }
+
+            CoursePlacesBatchSaveRequest request = new CoursePlacesBatchSaveRequest(courseId, coursePlaceInfoList);
+
+            Long userId = course.getUserId();
+            String userRole = "ROLE_USER";
+            String accessToken = Jwts.builder()
+                    .signWith(Keys.hmacShaKeyFor(jwtSecretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS512)
+                    .claim("auth", userRole)
+                    .setIssuer("test")
+                    .setIssuedAt(Date.from(Instant.now()))
+                    .setExpiration(Date.from(Instant.now().plusSeconds(100)))
+                    .setSubject(userId.toString())
+                    .compact();
+
+            // when
+            ResultActions perform = mockMvc.perform(
+                    post("/course-places/batch")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                            .content(objectMapper.writeValueAsString(request))
+            );
+
+            // then
+            perform.andExpect(status().isBadRequest());
         }
     }
 }

--- a/course-service/src/test/resources/org/springframework/restdocs/templates/common-response-fields.snippet
+++ b/course-service/src/test/resources/org/springframework/restdocs/templates/common-response-fields.snippet
@@ -1,0 +1,10 @@
+.{{title}}
+|===
+|이름|설명
+
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+|===

--- a/course-service/src/test/resources/org/springframework/restdocs/templates/path-parameters.snippet
+++ b/course-service/src/test/resources/org/springframework/restdocs/templates/path-parameters.snippet
@@ -1,0 +1,10 @@
+.`{{title}}`
+|===
+|파라미터 이름|설명
+
+{{#parameters}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/parameters}}
+
+|===

--- a/course-service/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/course-service/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,0 +1,12 @@
+.{{title}}
+|===
+|필드명|타입|필수값|설명
+
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+|===

--- a/course-service/src/test/resources/org/springframework/restdocs/templates/request-headers.snippet
+++ b/course-service/src/test/resources/org/springframework/restdocs/templates/request-headers.snippet
@@ -1,0 +1,11 @@
+.{{title}}
+|===
+|헤더 이름|필수값 여부|설명
+
+{{#headers}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/headers}}
+
+|===

--- a/course-service/src/test/resources/org/springframework/restdocs/templates/request-parameters.snippet
+++ b/course-service/src/test/resources/org/springframework/restdocs/templates/request-parameters.snippet
@@ -1,0 +1,11 @@
+.{{title}}
+|===
+|파라미터 이름|필수값 여부|설명
+
+{{#parameters}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/parameters}}
+
+|===

--- a/course-service/src/test/resources/org/springframework/restdocs/templates/request-parts.snippet
+++ b/course-service/src/test/resources/org/springframework/restdocs/templates/request-parts.snippet
@@ -1,0 +1,11 @@
+.{{title}}
+|===
+|파트 이름|필수값 여부|설명
+
+{{#requestParts}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/requestParts}}
+
+|===

--- a/course-service/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
+++ b/course-service/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
@@ -1,0 +1,11 @@
+.{{title}}
+|===
+|필드명|타입|설명
+
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+|===

--- a/course-service/src/test/resources/static/test-img2.png
+++ b/course-service/src/test/resources/static/test-img2.png
@@ -1,0 +1,5 @@
+23r235r4tgq34gq34t
+c134tg235tg
+23v5t23v4gt342tf23
+4tg34td234tb3q45tcd234
+btq34gtf34ct234qbtq34gq


### PR DESCRIPTION
### 코스 등록 기능과 관련된 도메인 로직 작성, API 구현
초기 계획에서는 코스 등록 API를 작성 할 때, 코스의 모든 데이터를 한번에 받으려고 했습니다.
코스 등록에 필요한 데이터는 코스 이미지, 제목, 설명, 장소 리스트 입니다.
여기서 코스 장소는 JSON 형태의 데이터로, 장소명, 장소설명, 위도, 경도, 순서값 등을 가집니다.
이미지를 전송할 때에는 multipart/form-data 형태로 요청을 보내는데, 이와 함께 데이터를 보낼 순 있지만, JSON 데이터를 전송하려면, JSON 데이터의 각 필드를 key로, 필드의 값을 value로 나누어 object 형태가 아닌 파라미터로 전송해야 했습니다.
그럼 장소 리스트는 JSON List인데 이를 이미지와 함께 전송하려면, 각 필드의 배열 형태로 전송해야 합니다.
```
imgFile,
title,
description,

placeName[0],
placeName[1],
placeName[2],

placeLat[0],
placeLat[1],
placeLat[2],

placeLng[0],
placeLng[1],
placeLng[2],
```
위와 같은 형태가 됩니다.. 
이는 데이터를 전송하는 클라이언트 측에서도, 이를 받아서 처리하는 서버 측에서도 비효율적이라 생각했고, 영준님께서는 코스 저장, 코스 장소 저장 등으로 API를 나누고, 코스에 상태를 부여하여 처리하는 방법에 대해 의견을 제시하셨습니다.
제시해주신 방법이 아주 괜찮은 것 같아서, 이 방향으로 코드를 작성했습니다.

나누어진 API는 코스 등록, 코스 장소 리스트 등록 API 입니다.
코스 등록 : `POST /courses`
코스 장소 리스트 등록 : `POST /course-places/batch`

코스 장소 단건 등록 : `POST /course-places`
	- 해당 API는, 220829 오전 스크럼 전에 작성했던 API인데, 현재 기능에서는 사용하지 않으나, 추후 필요할 수도 있지 않을까 라는 마음에 일단 놔뒀습니다.

---
### 코스 장소 리스트 등록 RequestDto - List 검증
CoursePlacesBatchSaveRequest 클래스는 코스 장소 리스트를 요청 바디로 받기위한 클래스입니다.
해당 클래스에 정적 클래스 CoursePlaceInfo 는 코스 장소 정보들을 받기 위한 클래스로, 해당 클래스를 List 형태로 받습니다. 이 때, CoursePlaceInfo 클래스에 검증 애노테이션을 붙여도, 요청 바디 검증시 CoursePlacesBatchSaveRequest 클래스의 List<CoursePlaceInfo> 필드에는 검증이 적용되지 않았습니다.

검증을 원하는 List 필드에 `@Valid` 애노테이션을 붙이면 검증이 된다는 자료를 찾아서, 리스트 검증을 위해 `@Valid` 애노테이션을 붙였습니다.


---
### 테스트 코드 작성 및 Docs 작성
개발한 API 들에 대한 테스트 코드를 작성했습니다.
Rest Docs 작성시, User-Service 등 다른 서비스에서는 컨트롤러 테스트, Rest Docs 작성을 위한 테스트 코드를 따로 관리했습니다.
여기서 문제는.. User-Service에서 컨트롤러 및 서비스 로직이 변경되어 테스트 코드도 수정하게 되었는데, 같은 테스트 코드가 두 군데에 있다보니, 수정하기가 쉽지 않았습니다. 만약 서비스가 더 확장되어 테스트 코드가 수십 수백개라면… 너무 끔찍합니다..
이번에는 컨트롤러 테스트 코드에 문서 작성 코드를 함께 추가했는데, 솔직히 어떤 방법이 나은지 잘 모르겠습니다.
좀 더 좋은 방법을 생각해보고 싶은데 기능 개발이 너무 밀려있다보니, 빠르게 개발부터 하고 차차 생각해보면서 수정해야 할 것 같습니다.

RescDocs Config, Support 등의 클래스는, 추후 다시 사용할 수도 있다고 생각해서, 일단은 그냥 두었습니다.


