### PR TITLE
feat : User-service 유저 등록 라우팅 제거

### DIFF
--- a/api-gateway-service/src/main/java/com/comeon/apigatewayservice/config/ExcludeRoutePredicateFactory.java
+++ b/api-gateway-service/src/main/java/com/comeon/apigatewayservice/config/ExcludeRoutePredicateFactory.java
@@ -1,0 +1,63 @@
+package com.comeon.apigatewayservice.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.gateway.handler.predicate.AbstractRoutePredicateFactory;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.server.PathContainer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.util.pattern.PathPattern;
+import org.springframework.web.util.pattern.PathPatternParser;
+
+import java.util.function.Predicate;
+
+import static org.springframework.http.server.PathContainer.parsePath;
+
+@Slf4j
+@Component
+public class ExcludeRoutePredicateFactory extends AbstractRoutePredicateFactory<ExcludeRoutePredicateFactory.Config> {
+
+    private final PathPatternParser pathPatternParser = new PathPatternParser();
+
+    public ExcludeRoutePredicateFactory() {
+        super(Config.class);
+    }
+
+    @Override
+    public Predicate<ServerWebExchange> apply(Config config) {
+        log.info("[ExcludePredicate] path : {}, method : {}", config.getPattern(), config.getMethod());
+        return exchange -> {
+            HttpMethod requestMethod = exchange.getRequest().getMethod();
+            PathContainer requestPath = parsePath(exchange.getRequest().getURI().getRawPath());
+
+            PathPattern pathPattern = this.pathPatternParser.parse(config.getPattern());
+
+            if (pathPattern.matches(requestPath) && requestMethod == config.getMethod()) {
+                return false;
+            }
+            return true;
+        };
+    }
+
+    public static class Config {
+        private String pattern;
+        private HttpMethod method;
+
+        public String getPattern() {
+            return pattern;
+        }
+
+        public Config setPattern(String pattern) {
+            this.pattern = pattern;
+            return this;
+        }
+
+        public HttpMethod getMethod() {
+            return method;
+        }
+
+        public void setMethod(HttpMethod method) {
+            this.method = method;
+        }
+    }
+}

--- a/api-gateway-service/src/main/resources/application.yml
+++ b/api-gateway-service/src/main/resources/application.yml
@@ -45,6 +45,10 @@ spring:
           uri: lb://USER-SERVICE
           predicates:
             - Path=/users/**
+            - name: Exclude
+              args:
+                pattern: /users
+                method: POST
 
         - id: user-service
           uri: lb://USER-SERVICE


### PR DESCRIPTION
API-Gateway에서 `POST /users` 라우팅을 제거했습니다.

자바 코드로 라우팅 설정을 추가할까 하다가, 설정이 여기저기 널려있으면 찾아보기 힘들다고 생각했습니다.
그래서 RoutePredicateFactory를 구현하여 지정한 경로와 http 메서드의 요청은 제외할 수 있도록 했습니다.