### PR TITLE
build.gradle 수정

### DIFF
--- a/api-gateway-service/build.gradle
+++ b/api-gateway-service/build.gradle
@@ -83,7 +83,6 @@ tasks.named('test') {
 asciidoctor {
     configurations 'asciidoctorExtensions'
     inputs.dir snippetsDir
-    dependsOn test
 
     sources{
         include('**/index.adoc','**/common/*.adoc','**/enums/*.adoc')
@@ -102,6 +101,12 @@ task copyDocument(type: Copy) {
     into file("src/main/resources/static/docs")
 }
 
-bootJar {
+task buildDocument(type: Copy) {
     dependsOn copyDocument
+    from file("src/main/resources/static/docs")
+    into file("build/resources/main/static/docs")
+}
+
+bootJar {
+    dependsOn buildDocument
 }

--- a/auth-service/build.gradle
+++ b/auth-service/build.gradle
@@ -87,7 +87,6 @@ tasks.named('test') {
 asciidoctor {
 	configurations 'asciidoctorExtensions'
 	inputs.dir snippetsDir
-	dependsOn test
 
 	sources{
 		include('**/index.adoc','**/common/*.adoc','**/enum/*.adoc')
@@ -106,6 +105,11 @@ task copyDocument(type: Copy) {
 	into file("src/main/resources/static/docs")
 }
 
-bootJar {
+task buildDocument(type: Copy) {
 	dependsOn copyDocument
+	from file("src/main/resources/static/docs")
+	into file("build/resources/main/static/docs")
+}
+bootJar {
+	dependsOn buildDocument
 }

--- a/course-service/build.gradle
+++ b/course-service/build.gradle
@@ -97,7 +97,6 @@ tasks.named('test') {
 asciidoctor {
     configurations 'asciidoctorExtensions'
     inputs.dir snippetsDir
-    dependsOn test
 
     sources{
         include('**/index.adoc','**/common/*.adoc','**/enums/*.adoc','**/update/*.adoc')
@@ -116,8 +115,14 @@ task copyDocument(type: Copy) {
     into file("src/main/resources/static/docs")
 }
 
-bootJar {
+task buildDocument(type: Copy) {
     dependsOn copyDocument
+    from file("src/main/resources/static/docs")
+    into file("build/resources/main/static/docs")
+}
+
+bootJar {
+    dependsOn buildDocument
 }
 
 def querydslDir = "$buildDir/generated/querydsl"

--- a/meeting-service/build.gradle
+++ b/meeting-service/build.gradle
@@ -137,7 +137,6 @@ compileQuerydsl {
 asciidoctor {
     configurations 'asciidoctorExtensions'
     inputs.dir snippetsDir
-    dependsOn test
 
     sources{
         include('**/index.adoc','**/popup/*.adoc')
@@ -156,6 +155,12 @@ task copyDocument(type: Copy) {
     into file("src/main/resources/static/docs")
 }
 
-bootJar {
+task buildDocument(type: Copy) {
     dependsOn copyDocument
+    from file("src/main/resources/static/docs")
+    into file("build/resources/main/static/docs")
+}
+
+bootJar {
+    dependsOn buildDocument
 }

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -87,7 +87,6 @@ tasks.named('test') {
 asciidoctor {
     configurations 'asciidoctorExtensions'
     inputs.dir snippetsDir
-    dependsOn test
 
     sources{
         include('**/index.adoc','**/common/*.adoc','**/enums/*.adoc')
@@ -106,6 +105,12 @@ task copyDocument(type: Copy) {
     into file("src/main/resources/static/docs")
 }
 
-bootJar {
+task buildDocument(type: Copy) {
     dependsOn copyDocument
+    from file("src/main/resources/static/docs")
+    into file("build/resources/main/static/docs")
+}
+
+bootJar {
+    dependsOn buildDocument
 }


### PR DESCRIPTION
build.gradle : bootJar시 테스트 수행하지 않도록 수정, bootJar 수행시 asciidoctor output 파일들 jar 파일에 포함되도록 태스크 추가(buildDocument task)