### PR TITLE
ErrorResponse.code 필드명 변경, 모임 유저 이미지 조회 버그 수정

### DIFF
--- a/api-gateway-service/Dockerfile
+++ b/api-gateway-service/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:20-ea-11
 VOLUME /tmp
-COPY build/libs/api-gateway-service-1.0.1.jar api-gateway-service.jar
+COPY build/libs/api-gateway-service-1.0.2.jar api-gateway-service.jar
 ENTRYPOINT ["java", "-jar", "api-gateway-service.jar"]

--- a/api-gateway-service/build.gradle
+++ b/api-gateway-service/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.comeon'
-version = '1.0.1'
+version = '1.0.2'
 sourceCompatibility = '11'
 
 configurations {

--- a/api-gateway-service/src/main/java/com/comeon/apigatewayservice/common/response/ApiResponse.java
+++ b/api-gateway-service/src/main/java/com/comeon/apigatewayservice/common/response/ApiResponse.java
@@ -77,7 +77,7 @@ public class ApiResponse<T> {
 
     private static ErrorResponse createErrorResponse(ErrorCode errorCode) {
         return ErrorResponse.builder()
-                .code(errorCode.getCode())
+                .errorCode(errorCode.getCode())
                 .message(errorCode.getMessage())
                 .build();
     }

--- a/api-gateway-service/src/main/java/com/comeon/apigatewayservice/common/response/ErrorResponse.java
+++ b/api-gateway-service/src/main/java/com/comeon/apigatewayservice/common/response/ErrorResponse.java
@@ -7,6 +7,6 @@ import lombok.*;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ErrorResponse<T> {
 
-    private Integer code;
+    private Integer errorCode;
     private T message;
 }

--- a/api-gateway-service/src/main/resources/static/index.html
+++ b/api-gateway-service/src/main/resources/static/index.html
@@ -16,13 +16,13 @@
                         <h4 class="card-header">API Gateway</h4>
                         <div class="card-body">
                             <p class="card-text">Microservice에 요청을 라우팅 합니다. 주로 로그인 인증, 서버 오류와 관련하여 예외를 반환합니다.</p>
-                            <h6 class="card-subtitle text-muted fw-bold">1.0.1 변경사항</h6>
-                            <p class="card-text text-muted">Prometheus 서버 연동이 추가되었습니다.</p>
+                            <h6 class="card-subtitle text-muted fw-bold">1.0.2 변경사항</h6>
+                            <p class="card-text text-muted">ErrorResponse 필드 네임이 수정되었습니다.</p>
                             <div class="d-flex justify-content-between align-items-center">
                                 <div class="btn-group">
                                     <a class="btn btn-sm btn-outline-secondary" href="./docs/index.html">문서 보러 가기</a>
                                 </div>
-                                <small class="text-primary">버전: 1.0.1 (2022-09-26)</small>
+                                <small class="text-primary">버전: 1.0.2 (2022-11-04)</small>
                             </div>
                         </div>
                     </div>
@@ -32,13 +32,13 @@
                         <h4 class="card-header">Auth Service</h4>
                         <div class="card-body">
                             <p class="card-text">전반적인 인증(회원 로그인)과 관련된 API를 제공합니다.</p>
-                            <h6 class="card-subtitle text-muted fw-bold">1.0.2 변경사항</h6>
-                            <p class="card-text text-muted">소셜 연결 끊기 및 로그아웃 기능이 추가되었습니다.</p>
+                            <h6 class="card-subtitle text-muted fw-bold">1.0.3 변경사항</h6>
+                            <p class="card-text text-muted">ErrorResponse 필드 네임이 수정되었습니다.</p>
                             <div class="d-flex justify-content-between align-items-center">
                                 <div class="btn-group">
                                     <a class="btn btn-sm btn-outline-secondary" href="./auth-service/docs/index.html">문서 보러 가기</a>
                                 </div>
-                                <small class="text-primary">버전: 1.0.2 (2022-09-29)</small>
+                                <small class="text-primary">버전: 1.0.3 (2022-11-04)</small>
                             </div>
                         </div>
                     </div>
@@ -48,13 +48,13 @@
                         <h4 class="card-header">User Service</h4>
                         <div class="card-body">
                             <p class="card-text">회원과 관련된 API를 제공합니다.</p>
-                            <h6 class="card-subtitle text-muted fw-bold">1.0.2 변경사항</h6>
-                            <p class="card-text text-muted">회원 탈퇴 API 내부 로직이 변경되었습니다.</p>
+                            <h6 class="card-subtitle text-muted fw-bold">1.0.3 변경사항</h6>
+                            <p class="card-text text-muted">ErrorResponse 필드 네임이 수정되었습니다.</p>
                             <div class="d-flex justify-content-between align-items-center">
                                 <div class="btn-group">
                                     <a class="btn btn-sm btn-outline-secondary" href="./user-service/docs/index.html">문서 보러 가기</a>
                                 </div>
-                                <small class="text-primary">버전: 1.0.2 (2022-09-29)</small>
+                                <small class="text-primary">버전: 1.0.3 (2022-11-04)</small>
                             </div>
                         </div>
                     </div>
@@ -64,13 +64,13 @@
                         <h4 class="card-header">Meeting Service</h4>
                         <div class="card-body">
                             <p class="card-text">모임과 관련된 API를 제공합니다.</p>
-                            <h6 class="card-subtitle text-muted fw-bold">1.0.3 변경사항</h6>
-                            <p class="card-text text-muted">모임 리스트 검색 로직이 변경되었습니다.</p>
+                            <h6 class="card-subtitle text-muted fw-bold">1.0.4 변경사항</h6>
+                            <p class="card-text text-muted">ErrorResponse 필드 네임이 수정되었습니다.</p>
                             <div class="d-flex justify-content-between align-items-center">
                                 <div class="btn-group">
                                     <a class="btn btn-sm btn-outline-secondary" href="./meeting-service/docs/index.html">문서 보러 가기</a>
                                 </div>
-                                <small class="text-primary">버전: 1.0.3 (2022-10-04)</small>
+                                <small class="text-primary">버전: 1.0.4 (2022-11-04)</small>
                             </div>
                         </div>
                     </div>
@@ -80,13 +80,13 @@
                         <h4 class="card-header">Course Service</h4>
                         <div class="card-body">
                             <p class="card-text">코스와 관련된 API를 제공합니다.</p>
-                            <h6 class="card-subtitle text-muted fw-bold">1.0.6 변경사항</h6>
-                            <p class="card-text text-muted">코스 장소 리스트 변경 API가 일부 업데이트 되었습니다.</p>
+                            <h6 class="card-subtitle text-muted fw-bold">1.0.7 변경사항</h6>
+                            <p class="card-text text-muted">ErrorResponse 필드 네임이 수정되었습니다.</p>
                             <div class="d-flex justify-content-between align-items-center">
                                 <div class="btn-group">
                                     <a class="btn btn-sm btn-outline-secondary" href="./course-service/docs/index.html">문서 보러 가기</a>
                                 </div>
-                                <small class="text-primary">버전: 1.0.6 (2022-10-19)</small>
+                                <small class="text-primary">버전: 1.0.7 (2022-11-04)</small>
                             </div>
                         </div>
                     </div>

--- a/api-gateway-service/src/test/java/com/comeon/apigatewayservice/docs/CommonResponseRestDocsTest.java
+++ b/api-gateway-service/src/test/java/com/comeon/apigatewayservice/docs/CommonResponseRestDocsTest.java
@@ -116,7 +116,7 @@ public class CommonResponseRestDocsTest {
                                 responseFields(
                                         beneathPath("data").withSubsectionId("error"),
                                         attributes(key("title").value("예외 응답 스펙")),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("오류 메시지를 반환합니다.")
                                 )
                         )

--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:20-ea-11
 VOLUME /tmp
-COPY build/libs/auth-service-1.0.2.jar auth-service.jar
+COPY build/libs/auth-service-1.0.3.jar auth-service.jar
 ENTRYPOINT ["java", "-jar", "auth-service.jar"]

--- a/auth-service/build.gradle
+++ b/auth-service/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.comeon'
-version = '1.0.2'
+version = '1.0.3'
 sourceCompatibility = '11'
 
 configurations {

--- a/auth-service/src/main/java/com/comeon/authservice/common/response/ApiResponse.java
+++ b/auth-service/src/main/java/com/comeon/authservice/common/response/ApiResponse.java
@@ -91,14 +91,14 @@ public class ApiResponse<T> {
 
     private static ErrorResponse createValidateErrorResponse(ErrorCode errorCode, MultiValueMap<String, String> errorResult) {
         return ErrorResponse.builder()
-                .code(errorCode.getCode())
+                .errorCode(errorCode.getCode())
                 .message(errorResult)
                 .build();
     }
 
     private static ErrorResponse createErrorResponse(ErrorCode errorCode) {
         return ErrorResponse.builder()
-                .code(errorCode.getCode())
+                .errorCode(errorCode.getCode())
                 .message(errorCode.getMessage())
                 .build();
     }

--- a/auth-service/src/main/java/com/comeon/authservice/common/response/ErrorResponse.java
+++ b/auth-service/src/main/java/com/comeon/authservice/common/response/ErrorResponse.java
@@ -7,7 +7,7 @@ import lombok.*;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ErrorResponse<T> {
 
-    private Integer code;
+    private Integer errorCode;
     private T message;
 
 }

--- a/course-service/Dockerfile
+++ b/course-service/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:20-ea-11
 VOLUME /tmp
-COPY /build/libs/course-service-1.0.6.jar course-service.jar
+COPY /build/libs/course-service-1.0.7.jar course-service.jar
 ENTRYPOINT ["java", "-jar", "course-service.jar"]

--- a/course-service/build.gradle
+++ b/course-service/build.gradle
@@ -13,7 +13,7 @@ plugins {
 }
 
 group = 'com.comeon'
-version = '1.0.6'
+version = '1.0.7'
 sourceCompatibility = '11'
 
 configurations {

--- a/course-service/src/main/java/com/comeon/courseservice/web/common/response/ApiResponse.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/common/response/ApiResponse.java
@@ -86,14 +86,14 @@ public class ApiResponse<T> {
 
     private static ErrorResponse createErrorResponse(ErrorCode errorCode) {
         return ErrorResponse.builder()
-                .code(errorCode.getCode())
+                .errorCode(errorCode.getCode())
                 .message(errorCode.getMessage())
                 .build();
     }
 
     private static ErrorResponse createValidateErrorResponse(ErrorCode errorCode, MultiValueMap<String, String> errorResult) {
         return ErrorResponse.builder()
-                .code(errorCode.getCode())
+                .errorCode(errorCode.getCode())
                 .message(errorResult)
                 .build();
     }

--- a/course-service/src/main/java/com/comeon/courseservice/web/common/response/ErrorResponse.java
+++ b/course-service/src/main/java/com/comeon/courseservice/web/common/response/ErrorResponse.java
@@ -8,7 +8,7 @@ import lombok.*;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ErrorResponse<T> {
 
-    private Integer code;
+    private Integer errorCode;
     private T message;
 
 }

--- a/course-service/src/test/java/com/comeon/courseservice/docs/CommonResponseRestDocsTest.java
+++ b/course-service/src/test/java/com/comeon/courseservice/docs/CommonResponseRestDocsTest.java
@@ -83,7 +83,7 @@ public class CommonResponseRestDocsTest extends CommonRestDocsSupport {
                                 RestDocsUtil.customResponseFields(
                                         "common-response", beneathPath("data").withSubsectionId("error"),
                                         attributes(key("title").value("예외 응답 스펙")),
-                                        fieldWithPath("code").description("API 내부에서 지정한 예외 코드를 반환합니다."),
+                                        fieldWithPath("errorCode").description("API 내부에서 지정한 예외 코드를 반환합니다."),
                                         fieldWithPath("message").description("예외 메시지를 반환합니다.")
                                 )
                         )

--- a/course-service/src/test/java/com/comeon/courseservice/web/course/controller/CourseControllerTest.java
+++ b/course-service/src/test/java/com/comeon/courseservice/web/course/controller/CourseControllerTest.java
@@ -173,7 +173,7 @@ public class CourseControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     fieldWithPath("message").type(JsonFieldType.OBJECT).description("오류 메시지"),
                                     fieldWithPath("message.imgFile").ignored(),
                                     fieldWithPath("message.description").ignored(),
@@ -316,7 +316,7 @@ public class CourseControllerTest extends AbstractControllerTest {
 
             //then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").exists())
+                    .andExpect(jsonPath("$.data.errorCode").exists())
                     .andExpect(jsonPath("$.data.message").exists());
 
             // docs
@@ -325,7 +325,7 @@ public class CourseControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("예외 응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     fieldWithPath("message").type(JsonFieldType.STRING).description("오류 메시지")
                             )
                     )
@@ -355,7 +355,7 @@ public class CourseControllerTest extends AbstractControllerTest {
 
             //then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.CAN_NOT_ACCESS_RESOURCE.getCode()))
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.CAN_NOT_ACCESS_RESOURCE.getCode()))
                     .andExpect(jsonPath("$.data.message").value(ErrorCode.CAN_NOT_ACCESS_RESOURCE.getMessage()));
 
             // docs
@@ -364,7 +364,7 @@ public class CourseControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("예외 응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     fieldWithPath("message").type(JsonFieldType.STRING).description("오류 메시지")
                             )
                     )
@@ -786,7 +786,7 @@ public class CourseControllerTest extends AbstractControllerTest {
 
             //then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.VALIDATION_FAIL.getCode()))
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.VALIDATION_FAIL.getCode()))
                     .andExpect(jsonPath("$.data.message").exists());
 
             // docs
@@ -795,7 +795,7 @@ public class CourseControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("예외 응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     subsectionWithPath("message").type(JsonFieldType.OBJECT).description("예외 메시지")
                             )
                     )
@@ -818,7 +818,7 @@ public class CourseControllerTest extends AbstractControllerTest {
 
             //then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.VALIDATION_FAIL.getCode()))
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.VALIDATION_FAIL.getCode()))
                     .andExpect(jsonPath("$.data.message").exists());
 
             // docs
@@ -827,7 +827,7 @@ public class CourseControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("예외 응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     subsectionWithPath("message").type(JsonFieldType.OBJECT).description("예외 메시지")
                             )
                     )
@@ -1076,7 +1076,7 @@ public class CourseControllerTest extends AbstractControllerTest {
 
             //then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.VALIDATION_FAIL.getCode()))
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.VALIDATION_FAIL.getCode()))
                     .andExpect(jsonPath("$.data.message").exists());
 
             // docs
@@ -1089,7 +1089,7 @@ public class CourseControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("오류 응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     subsectionWithPath("message").type(JsonFieldType.OBJECT).description("API 오류 응답 메시지")
                             )
                     )
@@ -1116,7 +1116,7 @@ public class CourseControllerTest extends AbstractControllerTest {
 
             //then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.VALIDATION_FAIL.getCode()))
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.VALIDATION_FAIL.getCode()))
                     .andExpect(jsonPath("$.data.message").exists());
 
             // docs
@@ -1135,7 +1135,7 @@ public class CourseControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("오류 응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     subsectionWithPath("message").type(JsonFieldType.OBJECT).description("API 오류 응답 메시지")
                             )
                     )
@@ -1347,7 +1347,7 @@ public class CourseControllerTest extends AbstractControllerTest {
 
             //then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").exists())
+                    .andExpect(jsonPath("$.data.errorCode").exists())
                     .andExpect(jsonPath("$.data.message").exists());
 
             // docs
@@ -1356,7 +1356,7 @@ public class CourseControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     fieldWithPath("message").type(JsonFieldType.OBJECT).description("API 오류 메시지"),
                                     fieldWithPath("message.description").ignored(),
                                     fieldWithPath("message.title").ignored()
@@ -1397,7 +1397,7 @@ public class CourseControllerTest extends AbstractControllerTest {
 
             //then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").exists())
+                    .andExpect(jsonPath("$.data.errorCode").exists())
                     .andExpect(jsonPath("$.data.message").exists());
 
             // docs
@@ -1406,7 +1406,7 @@ public class CourseControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     fieldWithPath("message").type(JsonFieldType.STRING).description("API 오류 메시지")
                             )
                     )
@@ -1453,7 +1453,7 @@ public class CourseControllerTest extends AbstractControllerTest {
 
             //then
             perform.andExpect(status().isForbidden())
-                    .andExpect(jsonPath("$.data.code").exists())
+                    .andExpect(jsonPath("$.data.errorCode").exists())
                     .andExpect(jsonPath("$.data.message").exists());
 
             // docs
@@ -1462,7 +1462,7 @@ public class CourseControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     fieldWithPath("message").type(JsonFieldType.STRING).description("API 오류 메시지")
                             )
                     )
@@ -1549,7 +1549,7 @@ public class CourseControllerTest extends AbstractControllerTest {
 
             //then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").exists())
+                    .andExpect(jsonPath("$.data.errorCode").exists())
                     .andExpect(jsonPath("$.data.message").exists());
 
             // docs
@@ -1558,7 +1558,7 @@ public class CourseControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     fieldWithPath("message").type(JsonFieldType.STRING).description("API 오류 메시지")
                             )
                     )
@@ -1596,7 +1596,7 @@ public class CourseControllerTest extends AbstractControllerTest {
 
             //then
             perform.andExpect(status().isForbidden())
-                    .andExpect(jsonPath("$.data.code").exists())
+                    .andExpect(jsonPath("$.data.errorCode").exists())
                     .andExpect(jsonPath("$.data.message").exists());
 
             // docs
@@ -1605,7 +1605,7 @@ public class CourseControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     fieldWithPath("message").type(JsonFieldType.STRING).description("API 오류 메시지")
                             )
                     )
@@ -1771,7 +1771,7 @@ public class CourseControllerTest extends AbstractControllerTest {
 
             // then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").exists())
+                    .andExpect(jsonPath("$.data.errorCode").exists())
                     .andExpect(jsonPath("$.data.message").exists());
 
             // docs
@@ -1780,7 +1780,7 @@ public class CourseControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     fieldWithPath("message").type(JsonFieldType.STRING).description("API 오류 메시지")
                             )
                     )
@@ -1811,7 +1811,7 @@ public class CourseControllerTest extends AbstractControllerTest {
 
             // then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").exists())
+                    .andExpect(jsonPath("$.data.errorCode").exists())
                     .andExpect(jsonPath("$.data.message").exists());
 
             // docs
@@ -1820,7 +1820,7 @@ public class CourseControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     fieldWithPath("message").type(JsonFieldType.STRING).description("API 오류 메시지")
                             )
                     )

--- a/course-service/src/test/java/com/comeon/courseservice/web/courseplace/controller/CoursePlaceControllerTest.java
+++ b/course-service/src/test/java/com/comeon/courseservice/web/courseplace/controller/CoursePlaceControllerTest.java
@@ -228,7 +228,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
 
             // then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.VALIDATION_FAIL.getCode()));
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.VALIDATION_FAIL.getCode()));
 
             // docs
             perform.andDo(
@@ -236,7 +236,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     subsectionWithPath("message").type(JsonFieldType.OBJECT).description("API 오류 메시지")
                             )
                     )
@@ -272,7 +272,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
 
             // then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.VALIDATION_FAIL.getCode()));
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.VALIDATION_FAIL.getCode()));
 
             // docs
             perform.andDo(
@@ -280,7 +280,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     subsectionWithPath("message").type(JsonFieldType.OBJECT).description("API 오류 메시지")
                             )
                     )
@@ -438,7 +438,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
 
             // then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.ENTITY_NOT_FOUND.getCode()))
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.ENTITY_NOT_FOUND.getCode()))
                     .andExpect(jsonPath("$.data.message").value(ErrorCode.ENTITY_NOT_FOUND.getMessage()));
 
             // docs
@@ -447,7 +447,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     fieldWithPath("message").type(JsonFieldType.STRING).description("API 오류 메시지")
                             )
                     )
@@ -488,7 +488,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
 
             // then
             perform.andExpect(status().isForbidden())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.NO_AUTHORITIES.getCode()))
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.NO_AUTHORITIES.getCode()))
                     .andExpect(jsonPath("$.data.message").value(ErrorCode.NO_AUTHORITIES.getMessage()));
 
             // docs
@@ -497,7 +497,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     fieldWithPath("message").type(JsonFieldType.STRING).description("API 오류 메시지")
                             )
                     )
@@ -533,7 +533,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
 
             // then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.VALIDATION_FAIL.getCode()))
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.VALIDATION_FAIL.getCode()))
                     .andExpect(jsonPath("$.data.message").exists());
 
             // docs
@@ -542,7 +542,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     subsectionWithPath("message").type(JsonFieldType.OBJECT).description("API 오류 메시지")
                             )
                     )
@@ -579,7 +579,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
 
             // then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.VALIDATION_FAIL.getCode()))
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.VALIDATION_FAIL.getCode()))
                     .andExpect(jsonPath("$.data.message").exists());
 
             // docs
@@ -588,7 +588,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     subsectionWithPath("message").type(JsonFieldType.OBJECT).description("API 오류 메시지")
                             )
                     )
@@ -625,7 +625,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
 
             // then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.VALIDATION_FAIL.getCode()))
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.VALIDATION_FAIL.getCode()))
                     .andExpect(jsonPath("$.data.message").exists());
 
             // docs
@@ -634,7 +634,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     subsectionWithPath("message").type(JsonFieldType.OBJECT).description("API 오류 메시지")
                             )
                     )
@@ -677,7 +677,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
 
             // then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.VALIDATION_FAIL.getCode()))
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.VALIDATION_FAIL.getCode()))
                     .andExpect(jsonPath("$.data.message").exists());
 
             // docs
@@ -686,7 +686,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     subsectionWithPath("message").type(JsonFieldType.OBJECT).description("API 오류 메시지")
                             )
                     )
@@ -748,7 +748,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
 
             // then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.VALIDATION_FAIL.getCode()))
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.VALIDATION_FAIL.getCode()))
                     .andExpect(jsonPath("$.data.message").exists());
 
             // docs
@@ -757,7 +757,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     subsectionWithPath("message").type(JsonFieldType.OBJECT).description("API 오류 메시지")
                             )
                     )
@@ -812,7 +812,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
 
             // then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.VALIDATION_FAIL.getCode()))
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.VALIDATION_FAIL.getCode()))
                     .andExpect(jsonPath("$.data.message").exists());
 
             // docs
@@ -821,7 +821,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     subsectionWithPath("message").type(JsonFieldType.OBJECT).description("API 오류 메시지")
                             )
                     )
@@ -886,7 +886,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
 
             // then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.PLACE_ORDER_DUPLICATE.getCode()))
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.PLACE_ORDER_DUPLICATE.getCode()))
                     .andExpect(jsonPath("$.data.message").value(ErrorCode.PLACE_ORDER_DUPLICATE.getMessage()));
 
             // docs
@@ -895,7 +895,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     fieldWithPath("message").type(JsonFieldType.STRING).description("API 오류 메시지")
                             )
                     )
@@ -960,7 +960,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
 
             // then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.PLACE_ORDER_NOT_START_ONE.getCode()))
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.PLACE_ORDER_NOT_START_ONE.getCode()))
                     .andExpect(jsonPath("$.data.message").value(ErrorCode.PLACE_ORDER_NOT_START_ONE.getMessage()));
 
             // docs
@@ -969,7 +969,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     fieldWithPath("message").type(JsonFieldType.STRING).description("API 오류 메시지")
                             )
                     )
@@ -1034,7 +1034,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
 
             // then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.PLACE_ORDER_NOT_CONSECUTIVE.getCode()))
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.PLACE_ORDER_NOT_CONSECUTIVE.getCode()))
                     .andExpect(jsonPath("$.data.message").value(ErrorCode.PLACE_ORDER_NOT_CONSECUTIVE.getMessage()));
 
             // docs
@@ -1043,7 +1043,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     fieldWithPath("message").type(JsonFieldType.STRING).description("API 오류 메시지")
                             )
                     )
@@ -1086,7 +1086,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
 
             // then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.VALIDATION_FAIL.getCode()))
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.VALIDATION_FAIL.getCode()))
                     .andExpect(jsonPath("$.data.message").exists());
 
             // docs
@@ -1095,7 +1095,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     subsectionWithPath("message").type(JsonFieldType.OBJECT).description("API 오류 메시지")
                             )
                     )
@@ -1202,7 +1202,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
 
             // then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.CAN_NOT_ACCESS_RESOURCE.getCode()))
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.CAN_NOT_ACCESS_RESOURCE.getCode()))
                     .andExpect(jsonPath("$.data.message").value(ErrorCode.CAN_NOT_ACCESS_RESOURCE.getMessage()));
 
             // docs
@@ -1211,7 +1211,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("예외 응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     fieldWithPath("message").type(JsonFieldType.STRING).description("오류 메시지")
                             )
                     )
@@ -1238,7 +1238,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
 
             // then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.ENTITY_NOT_FOUND.getCode()))
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.ENTITY_NOT_FOUND.getCode()))
                     .andExpect(jsonPath("$.data.message").value(ErrorCode.ENTITY_NOT_FOUND.getMessage()));
 
             // docs
@@ -1247,7 +1247,7 @@ public class CoursePlaceControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("예외 응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     fieldWithPath("message").type(JsonFieldType.STRING).description("오류 메시지")
                             )
                     )

--- a/meeting-service/Dockerfile
+++ b/meeting-service/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:20-ea-11
 VOLUME /tmp
-COPY build/libs/meeting-service-1.0.3.jar meeting-service.jar
+COPY build/libs/meeting-service-1.0.4.jar meeting-service.jar
 ENTRYPOINT ["java", "-jar", "meeting-service.jar"]

--- a/meeting-service/build.gradle
+++ b/meeting-service/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 group = 'com.comeon'
-version = '1.0.3'
+version = '1.0.4'
 sourceCompatibility = '11'
 
 configurations {

--- a/meeting-service/src/main/java/com/comeon/meetingservice/web/common/exception/CommonExControllerAdvice.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/web/common/exception/CommonExControllerAdvice.java
@@ -14,7 +14,6 @@ import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.servlet.NoHandlerFoundException;
 
 @Slf4j
 @RestControllerAdvice
@@ -35,7 +34,7 @@ public class CommonExControllerAdvice {
 
         ErrorResponse<MultiValueMap<String, String>> errorResponse =
                 ErrorResponse.<MultiValueMap<String, String>>builder()
-                        .code(e.getErrorCode().getCode())
+                        .errorCode(e.getErrorCode().getCode())
                         .message(e.getErrorMap())
                         .build();
         return ApiResponse.createCustom(ApiResponseCode.BAD_PARAMETER, errorResponse);
@@ -48,7 +47,7 @@ public class CommonExControllerAdvice {
 
         ErrorResponse<String> errorResponse =
                 ErrorResponse.<String>builder()
-                        .code(ErrorCode.HTTP_MESSAGE_NOT_READABLE.getCode())
+                        .errorCode(ErrorCode.HTTP_MESSAGE_NOT_READABLE.getCode())
                         .message(ErrorCode.HTTP_MESSAGE_NOT_READABLE.getMessage())
                         .build();
         return ApiResponse.createCustom(ApiResponseCode.BAD_PARAMETER, errorResponse);
@@ -61,7 +60,7 @@ public class CommonExControllerAdvice {
 
         ErrorResponse<String> errorResponse =
                 ErrorResponse.<String>builder()
-                        .code(ErrorCode.AUTHORIZATION_FAIL.getCode())
+                        .errorCode(ErrorCode.AUTHORIZATION_FAIL.getCode())
                         .message(e.getMessage())
                         .build();
         return ApiResponse.createCustom(ApiResponseCode.FORBIDDEN, errorResponse);
@@ -74,7 +73,7 @@ public class CommonExControllerAdvice {
 
         ErrorResponse<String> errorResponse =
                 ErrorResponse.<String>builder()
-                        .code(ErrorCode.UNSUPPORTED_METHOD.getCode())
+                        .errorCode(ErrorCode.UNSUPPORTED_METHOD.getCode())
                         .message(ErrorCode.UNSUPPORTED_METHOD.getMessage())
                         .build();
         return ApiResponse.createCustom(ApiResponseCode.BAD_PARAMETER, errorResponse);
@@ -87,7 +86,7 @@ public class CommonExControllerAdvice {
 
         ErrorResponse<String> errorResponse =
                 ErrorResponse.<String>builder()
-                        .code(ErrorCode.UNSPECIFIED_ERROR.getCode())
+                        .errorCode(ErrorCode.UNSPECIFIED_ERROR.getCode())
                         .message(ErrorCode.UNSPECIFIED_ERROR.getMessage())
                         .build();
         return ApiResponse.createCustom(ApiResponseCode.SERVER_ERROR, errorResponse);

--- a/meeting-service/src/main/java/com/comeon/meetingservice/web/common/feign/FeignErrorDecoder.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/web/common/feign/FeignErrorDecoder.java
@@ -31,7 +31,7 @@ public class FeignErrorDecoder implements ErrorDecoder {
                                 }.getType());
 
                         ErrorResponse<String> data = courseServiceApiResponse.getData();
-                        Integer errorCode = data.getCode();
+                        Integer errorCode = data.getErrorCode();
                         switch (errorCode) {
                             case 906:
                                 throw new CustomException(data.getMessage(), ErrorCode.COURSE_NOT_AVAILABLE);

--- a/meeting-service/src/main/java/com/comeon/meetingservice/web/common/feign/userservice/response/UserListResponse.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/web/common/feign/userservice/response/UserListResponse.java
@@ -12,6 +12,6 @@ public class UserListResponse {
 
     private Long userId;
     private String nickname;
-    private String profileImageUrl;
+    private String profileImgUrl;
     private UserStatus status;
 }

--- a/meeting-service/src/main/java/com/comeon/meetingservice/web/common/response/ApiResponse.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/web/common/response/ApiResponse.java
@@ -1,12 +1,10 @@
 package com.comeon.meetingservice.web.common.response;
 
 import com.comeon.meetingservice.common.exception.ErrorCode;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
 
 import java.time.LocalDateTime;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.*;
 import static lombok.AccessLevel.*;
 
 @Getter
@@ -86,7 +84,7 @@ public class ApiResponse<T> {
 
     private static ErrorResponse createErrorResponse(ErrorCode errorCode) {
         return ErrorResponse.builder()
-                .code(errorCode.getCode())
+                .errorCode(errorCode.getCode())
                 .message(errorCode.getMessage())
                 .build();
     }

--- a/meeting-service/src/main/java/com/comeon/meetingservice/web/common/response/ErrorResponse.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/web/common/response/ErrorResponse.java
@@ -9,7 +9,7 @@ import static lombok.AccessLevel.*;
 @AllArgsConstructor(access = PRIVATE)
 public class ErrorResponse<T> {
 
-    private Integer code;
+    private Integer errorCode;
     private T message;
 
 }

--- a/meeting-service/src/main/java/com/comeon/meetingservice/web/meeting/query/MeetingQueryService.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/web/meeting/query/MeetingQueryService.java
@@ -166,7 +166,7 @@ public class MeetingQueryService {
                     return MeetingDetailUserResponse.toResponse(
                             meetingUserEntity,
                             userInfo.getNickname(),
-                            userInfo.getProfileImageUrl());
+                            userInfo.getProfileImgUrl());
                 })
                 .collect(Collectors.toList());
     }

--- a/meeting-service/src/main/java/com/comeon/meetingservice/web/meetingdate/query/MeetingDateQueryService.java
+++ b/meeting-service/src/main/java/com/comeon/meetingservice/web/meetingdate/query/MeetingDateQueryService.java
@@ -7,15 +7,10 @@ import com.comeon.meetingservice.domain.meetingdate.entity.MeetingDateEntity;
 import com.comeon.meetingservice.domain.meetinguser.entity.MeetingUserEntity;
 import com.comeon.meetingservice.web.common.feign.userservice.UserFeignService;
 import com.comeon.meetingservice.web.common.feign.userservice.response.UserListResponse;
-import com.comeon.meetingservice.web.common.feign.userservice.response.UserServiceApiResponse;
-import com.comeon.meetingservice.web.common.feign.userservice.UserServiceFeignClient;
-import com.comeon.meetingservice.web.common.feign.userservice.response.UserServiceListResponse;
 import com.comeon.meetingservice.web.meetingdate.response.MeetingDateDetailResponse;
 import com.comeon.meetingservice.web.meetingdate.response.MeetingDateDetailUserResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cloud.client.circuitbreaker.CircuitBreaker;
-import org.springframework.cloud.client.circuitbreaker.CircuitBreakerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -62,7 +57,7 @@ public class MeetingDateQueryService {
                     return MeetingDateDetailUserResponse.toResponse(
                             meetingUserEntity,
                             userInfo.getNickname(),
-                            userInfo.getProfileImageUrl());
+                            userInfo.getProfileImgUrl());
                 })
                 .collect(Collectors.toList());
     }

--- a/meeting-service/src/test/java/com/comeon/meetingservice/web/meeting/MeetingControllerTest.java
+++ b/meeting-service/src/test/java/com/comeon/meetingservice/web/meeting/MeetingControllerTest.java
@@ -175,7 +175,7 @@ class MeetingControllerTest extends ControllerTestBase {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.BAD_PARAMETER.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.VALIDATION_FAIL.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.VALIDATION_FAIL.getCode())))
 
                         .andDo(document("meeting-create-error-param",
                                 preprocessRequest(prettyPrint()),
@@ -187,7 +187,7 @@ class MeetingControllerTest extends ControllerTestBase {
                                         partWithName("image").description("모임 이미지")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.OBJECT).description("어떤 파라미터가 검증에 실패했는지 표시"),
                                         fieldWithPath("message.title").type(JsonFieldType.ARRAY).description("검증에 실패한 이유"),
                                         fieldWithPath("message.endDate").type(JsonFieldType.ARRAY).description("검증에 실패한 이유"),
@@ -238,7 +238,7 @@ class MeetingControllerTest extends ControllerTestBase {
                         .andExpect(status().isNotFound())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.NOT_FOUND.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.COURSE_NOT_FOUND.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.COURSE_NOT_FOUND.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.COURSE_NOT_FOUND.getMessage())))
 
                         .andDo(document("meeting-create-error-course-id",
@@ -257,7 +257,7 @@ class MeetingControllerTest extends ControllerTestBase {
                                         partWithName("image").description("모임 이미지")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -304,7 +304,7 @@ class MeetingControllerTest extends ControllerTestBase {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.BAD_PARAMETER.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.COURSE_NOT_AVAILABLE.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.COURSE_NOT_AVAILABLE.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.COURSE_NOT_AVAILABLE.getMessage())))
 
                         .andDo(document("meeting-create-error-course-not-available",
@@ -323,7 +323,7 @@ class MeetingControllerTest extends ControllerTestBase {
                                         partWithName("image").description("모임 이미지")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -370,7 +370,7 @@ class MeetingControllerTest extends ControllerTestBase {
                         .andExpect(status().isInternalServerError())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.SERVER_ERROR.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.COURSE_SERVICE_ERROR.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.COURSE_SERVICE_ERROR.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.COURSE_SERVICE_ERROR.getMessage())))
 
                         .andDo(document("meeting-create-error-course-service",
@@ -389,7 +389,7 @@ class MeetingControllerTest extends ControllerTestBase {
                                         partWithName("image").description("모임 이미지")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -441,7 +441,7 @@ class MeetingControllerTest extends ControllerTestBase {
                         .andExpect(status().isInternalServerError())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.SERVER_ERROR.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.UPLOAD_FAIL.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.UPLOAD_FAIL.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.UPLOAD_FAIL.getMessage())))
 
                         .andDo(document("meeting-create-error-upload",
@@ -460,7 +460,7 @@ class MeetingControllerTest extends ControllerTestBase {
                                         partWithName("image").description("모임 이미지")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("어떤 파라미터가 검증에 실패했는지 표시")
                                 ))
                         )
@@ -611,7 +611,7 @@ class MeetingControllerTest extends ControllerTestBase {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.BAD_PARAMETER.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.VALIDATION_FAIL.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.VALIDATION_FAIL.getCode())))
 
                         .andDo(document("meeting-modify-error-param",
                                 preprocessRequest(prettyPrint()),
@@ -626,7 +626,7 @@ class MeetingControllerTest extends ControllerTestBase {
                                         parameterWithName("endDate").description("수정할 종료일").attributes(key("format").value("yyyy-MM-dd"))
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.OBJECT).description("어떤 파라미터가 검증에 실패했는지 표시"),
                                         fieldWithPath("message.title").type(JsonFieldType.ARRAY).description("검증에 실패한 이유"),
                                         fieldWithPath("message.startDate").type(JsonFieldType.ARRAY).description("검증에 실패한 이유")
@@ -676,7 +676,7 @@ class MeetingControllerTest extends ControllerTestBase {
                         .andExpect(status().isInternalServerError())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.SERVER_ERROR.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.UPLOAD_FAIL.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.UPLOAD_FAIL.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.UPLOAD_FAIL.getMessage())))
 
                         .andDo(document("meeting-modify-error-upload",
@@ -695,7 +695,7 @@ class MeetingControllerTest extends ControllerTestBase {
                                         partWithName("image").description("모임 이미지")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("어떤 파라미터가 검증에 실패했는지 표시")
                                 ))
                         )
@@ -731,7 +731,7 @@ class MeetingControllerTest extends ControllerTestBase {
                         .andExpect(status().isNotFound())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.NOT_FOUND.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.ENTITY_NOT_FOUND.getMessage())))
 
                         .andDo(document("meeting-modify-error-meeting-id",
@@ -749,7 +749,7 @@ class MeetingControllerTest extends ControllerTestBase {
                                         parameterWithName("endDate").description("수정할 종료일").attributes(key("format").value("yyyy-MM-dd"))
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -785,7 +785,7 @@ class MeetingControllerTest extends ControllerTestBase {
                         .andExpect(status().isForbidden())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.FORBIDDEN.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getMessage())))
 
                         .andDo(document("meeting-modify-error-not-joined",
@@ -803,7 +803,7 @@ class MeetingControllerTest extends ControllerTestBase {
                                         parameterWithName("endDate").description("수정할 종료일").attributes(key("format").value("yyyy-MM-dd"))
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -839,7 +839,7 @@ class MeetingControllerTest extends ControllerTestBase {
                         .andExpect(status().isForbidden())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.FORBIDDEN.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.AUTHORIZATION_FAIL.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.AUTHORIZATION_FAIL.getCode())))
 
                         .andDo(document("meeting-modify-error-authorization",
                                 preprocessRequest(prettyPrint()),
@@ -856,7 +856,7 @@ class MeetingControllerTest extends ControllerTestBase {
                                         parameterWithName("endDate").description("수정할 종료일").attributes(key("format").value("yyyy-MM-dd"))
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -932,7 +932,7 @@ class MeetingControllerTest extends ControllerTestBase {
                         .andExpect(status().isNotFound())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.NOT_FOUND.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.ENTITY_NOT_FOUND.getMessage())))
 
                         .andDo(document("meeting-delete-error-meeting-id",
@@ -945,7 +945,7 @@ class MeetingControllerTest extends ControllerTestBase {
                                         parameterWithName("meetingId").description("삭제(탈퇴)하려는 모임의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -972,7 +972,7 @@ class MeetingControllerTest extends ControllerTestBase {
                         .andExpect(status().isForbidden())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.FORBIDDEN.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getMessage())))
 
                         .andDo(document("meeting-delete-error-not-joined",
@@ -985,7 +985,7 @@ class MeetingControllerTest extends ControllerTestBase {
                                         parameterWithName("meetingId").description("삭제(탈퇴)하려는 모임의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -1444,7 +1444,7 @@ class MeetingControllerTest extends ControllerTestBase {
                         .andExpect(status().isNotFound())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.NOT_FOUND.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.ENTITY_NOT_FOUND.getMessage())))
 
                         .andDo(document("meeting-detail-error-meeting-id",
@@ -1457,7 +1457,7 @@ class MeetingControllerTest extends ControllerTestBase {
                                         parameterWithName("meetingId").description("조회하려는 모임의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -1481,7 +1481,7 @@ class MeetingControllerTest extends ControllerTestBase {
                         .andExpect(status().isForbidden())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.FORBIDDEN.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getMessage())))
 
                         .andDo(document("meeting-detail-error-not-joined",
@@ -1494,7 +1494,7 @@ class MeetingControllerTest extends ControllerTestBase {
                                         parameterWithName("meetingId").description("조회하려는 모임의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )

--- a/meeting-service/src/test/java/com/comeon/meetingservice/web/meetingcode/MeetingCodeControllerTest.java
+++ b/meeting-service/src/test/java/com/comeon/meetingservice/web/meetingcode/MeetingCodeControllerTest.java
@@ -102,7 +102,7 @@ class MeetingCodeControllerTest extends ControllerTestBase {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.BAD_PARAMETER.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.UNEXPIRED_CODE.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.UNEXPIRED_CODE.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.UNEXPIRED_CODE.getMessage())))
 
                         .andDo(document("code-modify-error-unexpired",
@@ -116,7 +116,7 @@ class MeetingCodeControllerTest extends ControllerTestBase {
                                         parameterWithName("codeId").description("수정하려는 모임 코드의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -146,7 +146,7 @@ class MeetingCodeControllerTest extends ControllerTestBase {
                         .andExpect(status().isNotFound())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.NOT_FOUND.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.ENTITY_NOT_FOUND.getMessage())))
 
                         .andDo(document("code-modify-error-code-id",
@@ -160,7 +160,7 @@ class MeetingCodeControllerTest extends ControllerTestBase {
                                         parameterWithName("codeId").description("수정하려는 모임 코드의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -188,7 +188,7 @@ class MeetingCodeControllerTest extends ControllerTestBase {
                         .andExpect(status().isNotFound())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.NOT_FOUND.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.ENTITY_NOT_FOUND.getMessage())))
 
                         .andDo(document("code-modify-error-meeting-id",
@@ -202,7 +202,7 @@ class MeetingCodeControllerTest extends ControllerTestBase {
                                         parameterWithName("codeId").description("수정하려는 모임 코드의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -230,7 +230,7 @@ class MeetingCodeControllerTest extends ControllerTestBase {
                         .andExpect(status().isForbidden())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.FORBIDDEN.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getMessage())))
 
                         .andDo(document("code-modify-error-not-joined",
@@ -244,7 +244,7 @@ class MeetingCodeControllerTest extends ControllerTestBase {
                                         parameterWithName("codeId").description("수정하려는 모임 코드의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -272,7 +272,7 @@ class MeetingCodeControllerTest extends ControllerTestBase {
                         .andExpect(status().isForbidden())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.FORBIDDEN.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.AUTHORIZATION_FAIL.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.AUTHORIZATION_FAIL.getCode())))
 
                         .andDo(document("code-modify-error-authorization",
                                 preprocessRequest(prettyPrint()),
@@ -285,7 +285,7 @@ class MeetingCodeControllerTest extends ControllerTestBase {
                                         parameterWithName("codeId").description("수정하려는 모임 코드의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -374,7 +374,7 @@ class MeetingCodeControllerTest extends ControllerTestBase {
                         .andExpect(status().isNotFound())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.NOT_FOUND.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.ENTITY_NOT_FOUND.getMessage())))
 
                         .andDo(document("code-detail-error-meeting-id",
@@ -388,7 +388,7 @@ class MeetingCodeControllerTest extends ControllerTestBase {
                                         parameterWithName("codeId").description("조회하려는 모임 코드의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -413,7 +413,7 @@ class MeetingCodeControllerTest extends ControllerTestBase {
                         .andExpect(status().isNotFound())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.NOT_FOUND.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.ENTITY_NOT_FOUND.getMessage())))
 
                         .andDo(document("code-detail-error-code-id",
@@ -427,7 +427,7 @@ class MeetingCodeControllerTest extends ControllerTestBase {
                                         parameterWithName("codeId").description("조회하려는 모임 코드의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -460,7 +460,7 @@ class MeetingCodeControllerTest extends ControllerTestBase {
                         .andExpect(status().isForbidden())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.FORBIDDEN.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getMessage())))
 
                         .andDo(document("code-detail-error-not-joined",
@@ -474,7 +474,7 @@ class MeetingCodeControllerTest extends ControllerTestBase {
                                         parameterWithName("codeId").description("조회하려는 모임 코드의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -507,7 +507,7 @@ class MeetingCodeControllerTest extends ControllerTestBase {
                         .andExpect(status().isForbidden())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.FORBIDDEN.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.AUTHORIZATION_FAIL.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.AUTHORIZATION_FAIL.getCode())))
 
                         .andDo(document("code-detail-error-authorization",
                                 preprocessRequest(prettyPrint()),
@@ -520,7 +520,7 @@ class MeetingCodeControllerTest extends ControllerTestBase {
                                         parameterWithName("codeId").description("조회하려는 모임 코드의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )

--- a/meeting-service/src/test/java/com/comeon/meetingservice/web/meetingdate/MeetingDateControllerTest.java
+++ b/meeting-service/src/test/java/com/comeon/meetingservice/web/meetingdate/MeetingDateControllerTest.java
@@ -138,7 +138,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.BAD_PARAMETER.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.DATE_NOT_WITHIN_PERIOD.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.DATE_NOT_WITHIN_PERIOD.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.DATE_NOT_WITHIN_PERIOD.getMessage())))
 
                         .andDo(document("date-create-error-not-within",
@@ -154,7 +154,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                                         fieldWithPath("date").description("추가할 날짜").attributes(key("format").value("yyyy-MM-dd"))
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -194,7 +194,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.BAD_PARAMETER.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.USER_ALREADY_SELECT.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.USER_ALREADY_SELECT.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.USER_ALREADY_SELECT.getMessage())))
 
                         .andDo(document("date-create-error-already-select",
@@ -210,7 +210,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                                         fieldWithPath("date").description("추가할 날짜").attributes(new Attributes.Attribute("format", "yyyy-MM-dd"))
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -247,7 +247,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.BAD_PARAMETER.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.HTTP_MESSAGE_NOT_READABLE.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.HTTP_MESSAGE_NOT_READABLE.getCode())))
 
                         .andDo(document("date-create-error-param",
                                 preprocessRequest(prettyPrint()),
@@ -262,7 +262,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                                         fieldWithPath("date").description("추가할 날짜").attributes(new Attributes.Attribute("format", "yyyy-MM-dd"))
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -300,7 +300,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                         .andExpect(status().isNotFound())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.NOT_FOUND.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.ENTITY_NOT_FOUND.getMessage())))
 
                         .andDo(document("date-create-error-meeting-id",
@@ -316,7 +316,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                                         fieldWithPath("date").description("추가할 날짜").attributes(new Attributes.Attribute("format", "yyyy-MM-dd"))
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -354,7 +354,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                         .andExpect(status().isForbidden())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.FORBIDDEN.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getMessage())))
 
                         .andDo(document("date-create-error-not-joined",
@@ -370,7 +370,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                                         fieldWithPath("date").description("추가할 날짜").attributes(new Attributes.Attribute("format", "yyyy-MM-dd"))
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -472,7 +472,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.BAD_PARAMETER.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.HTTP_MESSAGE_NOT_READABLE.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.HTTP_MESSAGE_NOT_READABLE.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.HTTP_MESSAGE_NOT_READABLE.getMessage())))
 
                         .andDo(document("date-modify-error-format",
@@ -489,7 +489,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                                         fieldWithPath("dateStatus").description("변경할 날짜의 상태").attributes(key("format").value("FIXED, UNFIXED"))
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -527,7 +527,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                         .andExpect(status().isNotFound())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.NOT_FOUND.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.ENTITY_NOT_FOUND.getMessage())))
 
                         .andDo(document("date-modify-error-meeting-id",
@@ -544,7 +544,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                                         fieldWithPath("dateStatus").description("변경할 날짜의 상태").attributes(key("format").value("FIXED, UNFIXED"))
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -583,7 +583,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                         .andExpect(status().isNotFound())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.NOT_FOUND.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.ENTITY_NOT_FOUND.getMessage())))
 
                         .andDo(document("date-modify-error-date-id",
@@ -600,7 +600,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                                         fieldWithPath("dateStatus").description("변경할 날짜의 상태").attributes(key("format").value("FIXED, UNFIXED"))
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -638,7 +638,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                         .andExpect(status().isForbidden())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.FORBIDDEN.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getMessage())))
 
                         .andDo(document("date-modify-error-not-joined",
@@ -655,7 +655,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                                         fieldWithPath("dateStatus").description("변경할 날짜의 상태").attributes(key("format").value("FIXED, UNFIXED"))
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -693,7 +693,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                         .andExpect(status().isForbidden())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.FORBIDDEN.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.AUTHORIZATION_FAIL.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.AUTHORIZATION_FAIL.getCode())))
 
                         .andDo(document("date-modify-error-authorization",
                                 preprocessRequest(prettyPrint()),
@@ -709,7 +709,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                                         fieldWithPath("dateStatus").description("변경할 날짜의 상태").attributes(key("format").value("FIXED, UNFIXED"))
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -797,7 +797,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.BAD_PARAMETER.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.USER_NOT_SELECT_DATE.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.USER_NOT_SELECT_DATE.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.USER_NOT_SELECT_DATE.getMessage())))
 
                         .andDo(document("date-delete-error-not-selected",
@@ -811,7 +811,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                                         parameterWithName("dateId").description("삭제하려는 모임 날짜의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -842,7 +842,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                         .andExpect(status().isNotFound())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.NOT_FOUND.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.ENTITY_NOT_FOUND.getMessage())))
 
                         .andDo(document("date-delete-error-meeting-id",
@@ -856,7 +856,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                                         parameterWithName("dateId").description("삭제하려는 모임 날짜의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -888,7 +888,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                         .andExpect(status().isNotFound())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.NOT_FOUND.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.ENTITY_NOT_FOUND.getMessage())))
 
                         .andDo(document("date-delete-error-date-id",
@@ -902,7 +902,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                                         parameterWithName("dateId").description("삭제하려는 모임 날짜의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -933,7 +933,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                         .andExpect(status().isForbidden())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.FORBIDDEN.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getMessage())))
 
                         .andDo(document("date-delete-error-not-joined",
@@ -947,7 +947,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                                         parameterWithName("dateId").description("삭제하려는 모임 날짜의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -1128,7 +1128,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
 
                         .andExpect(status().isNotFound())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.ENTITY_NOT_FOUND.getMessage())))
 
                         .andDo(document("date-detail-error-meeting-id",
@@ -1142,7 +1142,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                                         parameterWithName("dateId").description("조회하려는 모임 날짜의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -1166,7 +1166,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
 
                         .andExpect(status().isNotFound())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.ENTITY_NOT_FOUND.getMessage())))
 
                         .andDo(document("date-detail-error-date-id",
@@ -1180,7 +1180,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                                         parameterWithName("dateId").description("조회하려는 모임 날짜의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -1244,7 +1244,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
 
                         .andExpect(status().isForbidden())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getMessage())))
 
                         .andDo(document("date-detail-error-not-joined",
@@ -1258,7 +1258,7 @@ class MeetingDateControllerTest extends ControllerTestBase {
                                         parameterWithName("dateId").description("조회하려는 모임 날짜의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )

--- a/meeting-service/src/test/java/com/comeon/meetingservice/web/meetingplace/MeetingPlaceControllerTest.java
+++ b/meeting-service/src/test/java/com/comeon/meetingservice/web/meetingplace/MeetingPlaceControllerTest.java
@@ -175,7 +175,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                         .andExpect(status().isNotFound())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.NOT_FOUND.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.ENTITY_NOT_FOUND.getMessage())))
 
 
@@ -198,7 +198,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                                         fieldWithPath("memo").description("추가할 장소의 메모").optional()
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -252,7 +252,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.BAD_PARAMETER.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.VALIDATION_FAIL.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.VALIDATION_FAIL.getCode())))
 
                         .andDo(document("place-create-error-param",
                                 preprocessRequest(prettyPrint()),
@@ -273,7 +273,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                                         fieldWithPath("memo").description("추가할 장소의 메모").optional()
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.OBJECT).description("예외 메시지"),
                                         fieldWithPath("message.category").type(JsonFieldType.ARRAY).description("검증에 실패한 이유")
                                 ))
@@ -330,7 +330,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                         .andExpect(status().isForbidden())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.FORBIDDEN.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getMessage())))
 
                         .andDo(document("place-create-error-not-joined",
@@ -352,7 +352,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                                         fieldWithPath("memo").description("추가할 장소의 메모").optional()
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -408,7 +408,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                         .andExpect(status().isForbidden())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.FORBIDDEN.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.AUTHORIZATION_FAIL.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.AUTHORIZATION_FAIL.getCode())))
 
                         .andDo(document("place-create-error-authorization",
                                 preprocessRequest(prettyPrint()),
@@ -429,7 +429,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                                         fieldWithPath("memo").description("추가할 장소의 메모").optional()
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -675,7 +675,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.BAD_PARAMETER.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.VALIDATION_FAIL.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.VALIDATION_FAIL.getCode())))
 
                         .andDo(document("place-modify-error-info",
                                 preprocessRequest(prettyPrint()),
@@ -698,7 +698,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                                         fieldWithPath("order").description("수정할 장소의 순서").optional()
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.OBJECT).description("예외 메시지"),
                                         fieldWithPath("message.objectError").type(JsonFieldType.ARRAY).description("검증이 실패한 이유")
                                 ))
@@ -752,7 +752,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                         .andExpect(status().isNotFound())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.NOT_FOUND.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.ENTITY_NOT_FOUND.getMessage())))
 
                         .andDo(document("place-modify-error-place-id",
@@ -776,7 +776,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                                         fieldWithPath("order").description("수정할 장소의 순서").optional()
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -829,7 +829,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                         .andExpect(status().isNotFound())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.NOT_FOUND.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.ENTITY_NOT_FOUND.getMessage())))
 
                         .andDo(document("place-modify-error-meeting-id",
@@ -853,7 +853,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                                         fieldWithPath("order").description("수정할 장소의 순서").optional()
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -905,7 +905,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                         .andExpect(status().isForbidden())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.FORBIDDEN.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getMessage())))
 
                         .andDo(document("place-modify-error-not-joined",
@@ -929,7 +929,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                                         fieldWithPath("order").description("수정할 장소의 순서").optional()
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -981,7 +981,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                         .andExpect(status().isForbidden())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.FORBIDDEN.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.AUTHORIZATION_FAIL.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.AUTHORIZATION_FAIL.getCode())))
 
                         .andDo(document("place-modify-error-authorization",
                                 preprocessRequest(prettyPrint()),
@@ -1004,7 +1004,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                                         fieldWithPath("order").description("수정할 장소의 순서").optional()
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -1085,7 +1085,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                         .andExpect(status().isNotFound())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.NOT_FOUND.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.ENTITY_NOT_FOUND.getMessage())))
 
                         .andDo(document("place-delete-error-place-id",
@@ -1099,7 +1099,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                                         parameterWithName("placeId").description("삭제하려는 모임 장소의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -1127,7 +1127,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                         .andExpect(status().isNotFound())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.NOT_FOUND.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.ENTITY_NOT_FOUND.getMessage())))
 
                         .andDo(document("place-delete-error-meeting-id",
@@ -1141,7 +1141,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                                         parameterWithName("placeId").description("삭제하려는 모임 장소의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -1168,7 +1168,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                         .andExpect(status().isForbidden())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.FORBIDDEN.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getMessage())))
 
                         .andDo(document("place-delete-error-not-joined",
@@ -1182,7 +1182,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                                         parameterWithName("placeId").description("삭제하려는 모임 장소의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -1209,7 +1209,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                         .andExpect(status().isForbidden())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.FORBIDDEN.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.AUTHORIZATION_FAIL.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.AUTHORIZATION_FAIL.getCode())))
 
                         .andDo(document("place-delete-error-authorization",
                                 preprocessRequest(prettyPrint()),
@@ -1222,7 +1222,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                                         parameterWithName("placeId").description("삭제하려는 모임 장소의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -1331,7 +1331,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                         .andExpect(status().isNotFound())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.NOT_FOUND.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.ENTITY_NOT_FOUND.getMessage())))
 
                         .andDo(document("place-detail-error-place-id",
@@ -1345,7 +1345,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                                         parameterWithName("placeId").description("조회하려는 모임 장소의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -1391,7 +1391,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                         .andExpect(status().isNotFound())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.NOT_FOUND.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.ENTITY_NOT_FOUND.getMessage())))
 
                         .andDo(document("place-detail-error-meeting-id",
@@ -1405,7 +1405,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                                         parameterWithName("placeId").description("조회하려는 모임 장소의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -1447,7 +1447,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                         .andExpect(status().isForbidden())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.FORBIDDEN.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getMessage())))
 
                         .andDo(document("place-detail-error-not-joined",
@@ -1461,7 +1461,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                                         parameterWithName("placeId").description("조회하려는 모임 장소의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -1649,7 +1649,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                         .andExpect(status().isNotFound())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.NOT_FOUND.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.ENTITY_NOT_FOUND.getMessage())))
 
                         .andDo(document("place-list-error-meeting-id",
@@ -1662,7 +1662,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                                         parameterWithName("meetingId").description("조회할 모임 장소가 포함된 모임의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -1758,7 +1758,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                         .andExpect(status().isForbidden())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.FORBIDDEN.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getMessage())))
 
                         .andDo(document("place-list-error-not-joined",
@@ -1771,7 +1771,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                                         parameterWithName("meetingId").description("조회할 모임 장소가 포함된 모임의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -1867,7 +1867,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                         .andExpect(status().isForbidden())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.FORBIDDEN.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.AUTHORIZATION_FAIL.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.AUTHORIZATION_FAIL.getCode())))
 
                         .andDo(document("place-list-error-authorization",
                                 preprocessRequest(prettyPrint()),
@@ -1879,7 +1879,7 @@ class MeetingPlaceControllerTest extends ControllerTestBase {
                                         parameterWithName("meetingId").description("조회할 모임 장소가 포함된 모임의 ID")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )

--- a/meeting-service/src/test/java/com/comeon/meetingservice/web/meetinguser/MeetingUserControllerTest.java
+++ b/meeting-service/src/test/java/com/comeon/meetingservice/web/meetinguser/MeetingUserControllerTest.java
@@ -137,7 +137,7 @@ class MeetingUserControllerTest extends ControllerTestBase {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.BAD_PARAMETER.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.EXPIRED_CODE.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.EXPIRED_CODE.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.EXPIRED_CODE.getMessage())))
 
                         .andDo(document("user-create-error-expired-code",
@@ -150,7 +150,7 @@ class MeetingUserControllerTest extends ControllerTestBase {
                                         fieldWithPath("inviteCode").description("모임의 초대 코드")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -189,7 +189,7 @@ class MeetingUserControllerTest extends ControllerTestBase {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.BAD_PARAMETER.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.NONEXISTENT_CODE.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.NONEXISTENT_CODE.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.NONEXISTENT_CODE.getMessage())))
 
                         .andDo(document("user-create-error-nonexistent-code",
@@ -202,7 +202,7 @@ class MeetingUserControllerTest extends ControllerTestBase {
                                         fieldWithPath("inviteCode").description("모임의 초대 코드")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -241,7 +241,7 @@ class MeetingUserControllerTest extends ControllerTestBase {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.BAD_PARAMETER.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.USER_ALREADY_PARTICIPATE.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.USER_ALREADY_PARTICIPATE.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.USER_ALREADY_PARTICIPATE.getMessage())))
 
                         .andDo(document("user-create-error-already-participate",
@@ -254,7 +254,7 @@ class MeetingUserControllerTest extends ControllerTestBase {
                                         fieldWithPath("inviteCode").description("모임의 초대 코드")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -283,7 +283,7 @@ class MeetingUserControllerTest extends ControllerTestBase {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.BAD_PARAMETER.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.VALIDATION_FAIL.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.VALIDATION_FAIL.getCode())))
 
                         .andDo(document("user-create-error-param",
                                 preprocessRequest(prettyPrint()),
@@ -295,7 +295,7 @@ class MeetingUserControllerTest extends ControllerTestBase {
                                         fieldWithPath("inviteCode").description("모임의 초대 코드")
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.OBJECT).description("예외 메시지"),
                                         fieldWithPath("message.inviteCode").type(JsonFieldType.ARRAY).description("검증에 실패한 이유")
                                 ))
@@ -397,7 +397,7 @@ class MeetingUserControllerTest extends ControllerTestBase {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.BAD_PARAMETER.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.MODIFY_HOST_NOT_SUPPORT.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.MODIFY_HOST_NOT_SUPPORT.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.MODIFY_HOST_NOT_SUPPORT.getMessage())))
 
                         .andDo(document("user-modify-error-modifying-host",
@@ -414,7 +414,7 @@ class MeetingUserControllerTest extends ControllerTestBase {
                                         fieldWithPath("meetingRole").description("수정할 회원의 역할").attributes(key("format").value("EDITOR, PARTICIPANT"))
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -452,7 +452,7 @@ class MeetingUserControllerTest extends ControllerTestBase {
                         .andExpect(status().isBadRequest())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.BAD_PARAMETER.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.MODIFY_HOST_IMPOSSIBLE.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.MODIFY_HOST_IMPOSSIBLE.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.MODIFY_HOST_IMPOSSIBLE.getMessage())))
 
                         .andDo(document("user-modify-error-host-modified",
@@ -469,7 +469,7 @@ class MeetingUserControllerTest extends ControllerTestBase {
                                         fieldWithPath("meetingRole").description("수정할 회원의 역할").attributes(key("format").value("EDITOR, PARTICIPANT"))
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -508,7 +508,7 @@ class MeetingUserControllerTest extends ControllerTestBase {
                         .andExpect(status().isNotFound())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.NOT_FOUND.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.ENTITY_NOT_FOUND.getMessage())))
 
                         .andDo(document("user-modify-error-user-id",
@@ -525,7 +525,7 @@ class MeetingUserControllerTest extends ControllerTestBase {
                                         fieldWithPath("meetingRole").description("수정할 회원의 역할").attributes(key("format").value("EDITOR, PARTICIPANT"))
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -562,7 +562,7 @@ class MeetingUserControllerTest extends ControllerTestBase {
                         .andExpect(status().isNotFound())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.NOT_FOUND.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.ENTITY_NOT_FOUND.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.ENTITY_NOT_FOUND.getMessage())))
 
                         .andDo(document("user-modify-error-meeting-id",
@@ -579,7 +579,7 @@ class MeetingUserControllerTest extends ControllerTestBase {
                                         fieldWithPath("meetingRole").description("수정할 회원의 역할").attributes(key("format").value("EDITOR, PARTICIPANT"))
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -616,7 +616,7 @@ class MeetingUserControllerTest extends ControllerTestBase {
                         .andExpect(status().isForbidden())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.FORBIDDEN.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getCode())))
                         .andExpect(jsonPath("$.data.message", equalTo(ErrorCode.MEETING_USER_NOT_INCLUDE.getMessage())))
 
                         .andDo(document("user-modify-error-not-joined",
@@ -633,7 +633,7 @@ class MeetingUserControllerTest extends ControllerTestBase {
                                         fieldWithPath("meetingRole").description("수정할 회원의 역할").attributes(key("format").value("EDITOR, PARTICIPANT"))
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )
@@ -670,7 +670,7 @@ class MeetingUserControllerTest extends ControllerTestBase {
                         .andExpect(status().isForbidden())
                         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                         .andExpect(jsonPath("$.code", equalTo(ApiResponseCode.FORBIDDEN.name())))
-                        .andExpect(jsonPath("$.data.code", equalTo(ErrorCode.AUTHORIZATION_FAIL.getCode())))
+                        .andExpect(jsonPath("$.data.errorCode", equalTo(ErrorCode.AUTHORIZATION_FAIL.getCode())))
 
                         .andDo(document("user-modify-error-authorization",
                                 preprocessRequest(prettyPrint()),
@@ -686,7 +686,7 @@ class MeetingUserControllerTest extends ControllerTestBase {
                                         fieldWithPath("meetingRole").description("수정할 회원의 역할").attributes(key("format").value("EDITOR, PARTICIPANT"))
                                 ),
                                 responseFields(beneathPath("data").withSubsectionId("data"),
-                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description(errorCodeLink),
+                                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(errorCodeLink),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지")
                                 ))
                         )

--- a/meeting-service/src/test/java/com/comeon/meetingservice/web/restdocs/CommonDocumentationTest.java
+++ b/meeting-service/src/test/java/com/comeon/meetingservice/web/restdocs/CommonDocumentationTest.java
@@ -82,7 +82,7 @@ public class CommonDocumentationTest extends ControllerTestBase {
                         preprocessResponse(prettyPrint()),
                         commonResponseFields("common-response", beneathPath("data").withSubsectionId("data"),
                                 attributes(new Attributes.Attribute("title", "예외 응답 스펙")),
-                                fieldWithPath("code").type(JsonFieldType.NUMBER).description("API 내부에서 지정한 예외 코드를 반환합니다."),
+                                fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description("API 내부에서 지정한 예외 코드를 반환합니다."),
                                 fieldWithPath("message").type(JsonFieldType.STRING).description("예외 메시지를 반환합니다.")
                         )
                 ));

--- a/user-service/Dockerfile
+++ b/user-service/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:20-ea-11
 VOLUME /tmp
-COPY build/libs/user-service-1.0.2.jar user-service.jar
+COPY build/libs/user-service-1.0.3.jar user-service.jar
 ENTRYPOINT ["java", "-jar", "user-service.jar"]

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.comeon'
-version = '1.0.2'
+version = '1.0.3'
 sourceCompatibility = '11'
 
 configurations {

--- a/user-service/src/main/java/com/comeon/userservice/web/common/response/ApiResponse.java
+++ b/user-service/src/main/java/com/comeon/userservice/web/common/response/ApiResponse.java
@@ -86,14 +86,14 @@ public class ApiResponse<T> {
 
     private static ErrorResponse createErrorResponse(ErrorCode errorCode) {
         return ErrorResponse.builder()
-                .code(errorCode.getCode())
+                .errorCode(errorCode.getCode())
                 .message(errorCode.getMessage())
                 .build();
     }
 
     private static ErrorResponse createValidateErrorResponse(ErrorCode errorCode, MultiValueMap<String, String> errorResult) {
         return ErrorResponse.builder()
-                .code(errorCode.getCode())
+                .errorCode(errorCode.getCode())
                 .message(errorResult)
                 .build();
     }

--- a/user-service/src/main/java/com/comeon/userservice/web/common/response/ErrorResponse.java
+++ b/user-service/src/main/java/com/comeon/userservice/web/common/response/ErrorResponse.java
@@ -7,7 +7,7 @@ import lombok.*;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ErrorResponse<T> {
 
-    private Integer code;
+    private Integer errorCode;
     private T message;
 
 }

--- a/user-service/src/main/java/com/comeon/userservice/web/feign/FeignErrorDecoder.java
+++ b/user-service/src/main/java/com/comeon/userservice/web/feign/FeignErrorDecoder.java
@@ -31,7 +31,7 @@ public class FeignErrorDecoder implements ErrorDecoder {
                     );
 
             ErrorResponse errorResponse = authServiceApiResponse.getData();
-            switch (errorResponse.getCode()) {
+            switch (errorResponse.getErrorCode()) {
                 case 681: // 요청 데이터 검증 실패
                     throw new CustomException("oauthId가 없습니다.", ErrorCode.SERVER_ERROR);
                 case 682: // 유효하지 않은 oauthId

--- a/user-service/src/test/java/com/comeon/userservice/docs/CommonResponseRestDocsTest.java
+++ b/user-service/src/test/java/com/comeon/userservice/docs/CommonResponseRestDocsTest.java
@@ -81,7 +81,7 @@ public class CommonResponseRestDocsTest extends CommonRestDocsSupport {
                                 RestDocsUtil.customResponseFields(
                                         "common-response", beneathPath("data").withSubsectionId("error"),
                                         attributes(key("title").value("예외 응답 스펙")),
-                                        fieldWithPath("code").description("API 내부에서 지정한 예외 코드를 반환합니다."),
+                                        fieldWithPath("errorCode").description("API 내부에서 지정한 예외 코드를 반환합니다."),
                                         fieldWithPath("message").description("예외 메시지를 반환합니다.")
                                 )
                         )

--- a/user-service/src/test/java/com/comeon/userservice/web/profileimage/controller/ProfileImgControllerTest.java
+++ b/user-service/src/test/java/com/comeon/userservice/web/profileimage/controller/ProfileImgControllerTest.java
@@ -130,7 +130,7 @@ public class ProfileImgControllerTest extends AbstractControllerTest {
 
             // then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.VALIDATION_FAIL.getCode()))
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.VALIDATION_FAIL.getCode()))
                     .andExpect(jsonPath("$.data.message").isNotEmpty());
 
             // docs
@@ -143,7 +143,7 @@ public class ProfileImgControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("오류 응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     subsectionWithPath("message").type(JsonFieldType.OBJECT).description("요청 처리 성공 메시지")
                             )
                     )
@@ -229,7 +229,7 @@ public class ProfileImgControllerTest extends AbstractControllerTest {
 
             // then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.ENTITY_NOT_FOUND.getCode()))
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.ENTITY_NOT_FOUND.getCode()))
                     .andExpect(jsonPath("$.data.message").value(ErrorCode.ENTITY_NOT_FOUND.getMessage()));
 
             // docs
@@ -246,7 +246,7 @@ public class ProfileImgControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("오류 응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     fieldWithPath("message").type(JsonFieldType.STRING).description("API 오류 메시지")
                             )
                     )
@@ -279,7 +279,7 @@ public class ProfileImgControllerTest extends AbstractControllerTest {
 
             // then
             perform.andExpect(status().isForbidden())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.NO_AUTHORITIES.getCode()))
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.NO_AUTHORITIES.getCode()))
                     .andExpect(jsonPath("$.data.message").value(ErrorCode.NO_AUTHORITIES.getMessage()));
 
             // docs
@@ -296,7 +296,7 @@ public class ProfileImgControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("오류 응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     fieldWithPath("message").type(JsonFieldType.STRING).description("API 오류 메시지")
                             )
                     )

--- a/user-service/src/test/java/com/comeon/userservice/web/user/controller/UserControllerTest.java
+++ b/user-service/src/test/java/com/comeon/userservice/web/user/controller/UserControllerTest.java
@@ -234,7 +234,7 @@ public class UserControllerTest extends AbstractControllerTest {
 
             // then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.VALIDATION_FAIL.getCode()))
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.VALIDATION_FAIL.getCode()))
                     .andExpect(jsonPath("$.data.message").isNotEmpty());
 
             // docs
@@ -243,7 +243,7 @@ public class UserControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("오류 응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     subsectionWithPath("message").type(JsonFieldType.OBJECT).description("API 오류 메시지")
                             )
                     )
@@ -417,7 +417,7 @@ public class UserControllerTest extends AbstractControllerTest {
 
             // then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.ENTITY_NOT_FOUND.getCode()))
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.ENTITY_NOT_FOUND.getCode()))
                     .andExpect(jsonPath("$.data.message").value(ErrorCode.ENTITY_NOT_FOUND.getMessage()));
 
             // docs
@@ -426,7 +426,7 @@ public class UserControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("오류 응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     fieldWithPath("message").type(JsonFieldType.STRING).description("API 오류 메시지")
                             )
                     )
@@ -606,7 +606,7 @@ public class UserControllerTest extends AbstractControllerTest {
 
             // then
             perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.VALIDATION_FAIL.getCode()))
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.VALIDATION_FAIL.getCode()))
                     .andExpect(jsonPath("$.data.message").isNotEmpty());
 
             // docs
@@ -618,7 +618,7 @@ public class UserControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     subsectionWithPath("message").type(JsonFieldType.OBJECT).description("API 오류 메시지")
                             )
                     )
@@ -775,7 +775,7 @@ public class UserControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("오류 응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     subsectionWithPath("message").type(JsonFieldType.OBJECT).description("API 오류 메시지")
                             )
                     )
@@ -854,7 +854,7 @@ public class UserControllerTest extends AbstractControllerTest {
 
             // then
             perform.andExpect(status().isInternalServerError())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.AUTH_SERVICE_ERROR.getCode()))
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.AUTH_SERVICE_ERROR.getCode()))
                     .andExpect(jsonPath("$.data.message").value(ErrorCode.AUTH_SERVICE_ERROR.getMessage()));
 
             // docs
@@ -866,7 +866,7 @@ public class UserControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     subsectionWithPath("message").type(JsonFieldType.STRING).description("API 오류 메시지")
                             )
                     )
@@ -898,7 +898,7 @@ public class UserControllerTest extends AbstractControllerTest {
 
             // then
             perform.andExpect(status().isInternalServerError())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.KAKAO_API_ERROR.getCode()))
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.KAKAO_API_ERROR.getCode()))
                     .andExpect(jsonPath("$.data.message").value(ErrorCode.KAKAO_API_ERROR.getMessage()));
 
             // docs
@@ -910,7 +910,7 @@ public class UserControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     subsectionWithPath("message").type(JsonFieldType.STRING).description("API 오류 메시지")
                             )
                     )
@@ -942,7 +942,7 @@ public class UserControllerTest extends AbstractControllerTest {
 
             // then
             perform.andExpect(status().isInternalServerError())
-                    .andExpect(jsonPath("$.data.code").value(ErrorCode.SERVER_ERROR.getCode()))
+                    .andExpect(jsonPath("$.data.errorCode").value(ErrorCode.SERVER_ERROR.getCode()))
                     .andExpect(jsonPath("$.data.message").value(ErrorCode.SERVER_ERROR.getMessage()));
 
             // docs
@@ -954,7 +954,7 @@ public class UserControllerTest extends AbstractControllerTest {
                             responseFields(
                                     beneathPath("data").withSubsectionId("data"),
                                     attributes(key("title").value("응답 필드")),
-                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
+                                    fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description(RestDocsUtil.generateLinkCode(RestDocsUtil.DocUrl.ERROR_CODE)),
                                     subsectionWithPath("message").type(JsonFieldType.STRING).description("API 오류 메시지")
                             )
                     )


### PR DESCRIPTION
- ApiResponse.code와 ApiResponse.data.code 두 `code` 필드 네임이 다르면 좋을 것 같다는 프론트 측 요구사항에 따라 ErrorResponse.code 필드명을 ErrorResponse.errorCode로 수정하였습니다.

- 모임 상세 조회시, 모임 유저의 프로필 이미지가 조회되지 않는 버그를 수정했습니다.
   - 유저 서비스에서 잘 조회되었으나, 유저 서비스에서 프로필 이미지 응답 필드명은 profileImgUrl 이었고, 모임 서비스에서 프로필 이미지 응답 필드명은 profileImageUrl 이었습니다.
   - 각 필드명이 달라 FeignService에서 응답로 받지 못하는 문제였습니다.
